### PR TITLE
Validate workflow keys against :onyx/name vals in the catalog.

### DIFF
--- a/src/onyx/api.clj
+++ b/src/onyx/api.clj
@@ -89,6 +89,7 @@
 (deftype HttpCoordinator [conn]
   ISubmit
   (submit-job [this job]
+    (validate-workflow-names job)
     (let [leader (extensions/leader (:sync conn) :election)
           data (extensions/read-node (:sync conn) leader)
           uri (format "http://%s:%s/submit-job" (:host data) (:port data))


### PR DESCRIPTION
Closes https://github.com/MichaelDrogalis/onyx/issues/24, assuming I've understood it correctly.

Not sure if I've put the code in the right place. I couldn't see any files obviously pertaining to workflows where I could move flatten-workflow to. Let me know if there's anything wrong with it and I can improve it. Flatten-workflow is a little inefficient but I doubt it matters here?

Note, I've been unable to run the test suite because of the following error (happens with and without this change).

```
clojure.lang.ExceptionInfo: Error in component :queue in system onyx.system.OnyxCoordinator calling #'com.stuartsierra.component/start {:reason :com.stuartsierra.component/component-function-threw-exception, :function #'com.stuartsierra.component/start, :component #onyx.q
ueue.hornetq.HornetQConnection{:opts {:hornetq.embedded/config ["hornetq/clustered-1.xml" "hornetq/clustered-2.xml" "hornetq/clustered-3.xml" "hornetq/non-clustered-1.xml"], :zookeeper/server? true, :hornetq.udp/cluster-name "onyx-cluster", :zookeeper.server/port 2185, :o
nyx.coordinator/revoke-delay 50000, :hornetq.udp/group-port 9876, :hornetq.udp/refresh-timeout 5000, :hornetq/mode :udp, :hornetq.udp/discovery-timeout 5000, :onyx/id "b2fbc6ac-fcda-471e-bd53-9f84b3271bda", :hornetq/server? true, :zookeeper/address "127.0.0.1:2185", :horn
etq.udp/group-address "231.7.7.7", :hornetq.server/type :embedded}, :logging-config #onyx.logging_configuration.LoggingConfiguration{:file "onyx.log", :config nil}}, :system #onyx.system.OnyxCoordinator{:logging-config #onyx.logging_configuration.LoggingConfiguration{:fil
e "onyx.log", :config nil}, :queue #onyx.queue.hornetq.HornetQConnection{:opts {:hornetq.embedded/config ["hornetq/clustered-1.xml" "hornetq/clustered-2.xml" "hornetq/clustered-3.xml" "hornetq/non-clustered-1.xml"], :zookeeper/server? true, :hornetq.udp/cluster-name "onyx
-cluster", :zookeeper.server/port 2185, :onyx.coordinator/revoke-delay 50000, :hornetq.udp/group-port 9876, :hornetq.udp/refresh-timeout 5000, :hornetq/mode :udp, :hornetq.udp/discovery-timeout 5000, :onyx/id "b2fbc6ac-fcda-471e-bd53-9f84b3271bda", :hornetq/server? true,
:zookeeper/address "127.0.0.1:2185", :hornetq.udp/group-address "231.7.7.7", :hornetq.server/type :embedded}}, :sync #onyx.sync.zookeeper.ZooKeeper{:opts {:hornetq.embedded/config ["hornetq/clustered-1.xml" "hornetq/clustered-2.xml" "hornetq/clustered-3.xml" "hornetq/non-
clustered-1.xml"], :zookeeper/server? true, :hornetq.udp/cluster-name "onyx-cluster", :zookeeper.server/port 2185, :onyx.coordinator/revoke-delay 50000, :hornetq.udp/group-port 9876, :hornetq.udp/refresh-timeout 5000, :hornetq/mode :udp, :hornetq.udp/discovery-timeout 500
0, :onyx/id "b2fbc6ac-fcda-471e-bd53-9f84b3271bda", :hornetq/server? true, :zookeeper/address "127.0.0.1:2185", :hornetq.udp/group-address "231.7.7.7", :hornetq.server/type :embedded}}, :coordinator #onyx.coordinator.async.Coordinator{:revoke-delay 50000}}}
        at clojure.core$ex_info.invoke(core.clj:4403)
        at com.stuartsierra.component$try_action.invoke(component.clj:101)
        at com.stuartsierra.component$update_system$fn__14881.invoke(component.clj:124)
        at clojure.core.protocols$fn__6089.invoke(protocols.clj:127)
        at clojure.core.protocols$fn__6057$G__6052__6066.invoke(protocols.clj:19)
        at clojure.core.protocols$seq_reduce.invoke(protocols.clj:31)
        at clojure.core.protocols$fn__6080.invoke(protocols.clj:48)
        at clojure.core.protocols$fn__6031$G__6026__6044.invoke(protocols.clj:13)
        at clojure.core$reduce.invoke(core.clj:6289)
        at com.stuartsierra.component$update_system.doInvoke(component.clj:128)
        at clojure.lang.RestFn.invoke(RestFn.java:445)
        at com.stuartsierra.component$start_system.invoke(component.clj:150)
        at onyx.system.OnyxCoordinator$fn__20706.invoke(system.clj:34)
        at onyx.system$rethrow_component.invoke(system.clj:25)
        at onyx.system.OnyxCoordinator.start(system.clj:33)
        at onyx.coordinator.sim_test_utils$with_system.doInvoke(sim_test_utils.clj:32)
        at clojure.lang.RestFn.invoke(RestFn.java:423)
        at onyx.coordinator.concurrent_task_test$eval21173$fn__21174$fn__21175.invoke(concurrent_task_test.clj:11)
        at midje.util.thread_safe_var_nesting$with_altered_roots_STAR_.invoke(thread_safe_var_nesting.clj:32)
        at onyx.coordinator.concurrent_task_test$eval21173$fn__21174.invoke(concurrent_task_test.clj:11)
        at clojure.lang.AFn.applyToHelper(AFn.java:152)
        at clojure.lang.AFn.applyTo(AFn.java:144)
        at clojure.lang.AFunction$1.doInvoke(AFunction.java:29)
        at clojure.lang.RestFn.invoke(RestFn.java:397)
        at midje.checking.facts$check_one$fn__6175.invoke(facts.clj:31)
        at midje.checking.facts$check_one.invoke(facts.clj:30)
        at midje.checking.facts$creation_time_check.invoke(facts.clj:35)
        at onyx.coordinator.concurrent_task_test$eval21173.invoke(concurrent_task_test.clj:11)
        at clojure.lang.Compiler.eval(Compiler.java:6703)
```
