### PR TITLE
Intelligently pick ackers across physical machines.

### DIFF
--- a/src/onyx/extensions.clj
+++ b/src/onyx/extensions.clj
@@ -60,3 +60,6 @@
 (defmulti internal-complete-message (fn [messenger event id peer-link] (type messenger)))
 
 (defmulti internal-retry-message (fn [messenger event id peer-link] (type messenger)))
+
+(defmethod extensions/open-peer-site :default
+  [_ _] "localhost")

--- a/src/onyx/extensions.clj
+++ b/src/onyx/extensions.clj
@@ -61,5 +61,5 @@
 
 (defmulti internal-retry-message (fn [messenger event id peer-link] (type messenger)))
 
-(defmethod extensions/open-peer-site :default
+(defmethod open-peer-site :default
   [_ _] "localhost")

--- a/src/onyx/extensions.clj
+++ b/src/onyx/extensions.clj
@@ -41,6 +41,9 @@
 
 (defmulti peer-site (fn [messenger] (type messenger)))
 
+(defmulti get-peer-site (fn [replica peer]
+                          (:onyx.messaging/impl (:messaging replica))))
+
 (defmulti open-peer-site (fn [messenger assigned] (type messenger)))
 
 (defmulti connect-to-peer (fn [messenger event peer-site] (type messenger)))

--- a/src/onyx/log/commands/seal_output.clj
+++ b/src/onyx/log/commands/seal_output.clj
@@ -23,6 +23,7 @@
             (update-in [:jobs] (fn [coll] (remove (partial = (:job args)) coll)))
             (update-in [:jobs] vec)
             (update-in [:completed-jobs] conj (:job args))
+            (update-in [:completed-jobs] vec)
             (update-in [:allocations] dissoc (:job args))
             (update-in [:peer-state] merge (into {} (map (fn [p] {p :idle}) peers)))
             (reconfigure-cluster-workload)))

--- a/src/onyx/messaging/aeron.clj
+++ b/src/onyx/messaging/aeron.clj
@@ -54,6 +54,10 @@
     (assert port "Couldn't assign port - ran out of available ports.")
     {:aeron/port port}))
 
+(defmethod extensions/get-peer-site :aeron
+  [replica peer]
+  (get-in replica [:peer-sites peer :aeron/external-addr]))
+
 (defn handle-sent-message [inbound-ch decompress-f ^UnsafeBuffer buffer offset length header]
   (let [messages (protocol/read-messages-buf decompress-f buffer offset length)]
     (doseq [message messages]

--- a/src/onyx/messaging/core_async.clj
+++ b/src/onyx/messaging/core_async.clj
@@ -25,6 +25,10 @@
   [config peer-site peer-sites]
   peer-site)
 
+(defmethod extensions/get-peer-site :core.async
+  [replica peer]
+  "localhost")
+
 (defrecord CoreAsync [peer-group]
   component/Lifecycle
 

--- a/src/onyx/messaging/netty_tcp.clj
+++ b/src/onyx/messaging/netty_tcp.clj
@@ -101,6 +101,10 @@
     (assert port "Couldn't assign port - ran out of available ports.")
     {:netty/port port}))
 
+(defmethod extensions/get-peer-site :netty
+  [replica peer]
+  (get-in replica [:peer-sites peer :netty/external-addr]))
+
 (defn int32-frame-decoder
   []
   ; Offset 0, 4 byte header, skip those 4 bytes.

--- a/test/onyx/messaging/dummy_messenger.clj
+++ b/test/onyx/messaging/dummy_messenger.clj
@@ -13,6 +13,3 @@
 (defmethod extensions/peer-site onyx.messaging.dummy_messenger.DummyMessenger
   [messenger]
   {:address 1})
-
-(defmethod extensions/open-peer-site :default
-  [_ _] "localhost")

--- a/test/onyx/messaging/dummy_messenger.clj
+++ b/test/onyx/messaging/dummy_messenger.clj
@@ -13,3 +13,6 @@
 (defmethod extensions/peer-site onyx.messaging.dummy_messenger.DummyMessenger
   [messenger]
   {:address 1})
+
+(defmethod extensions/open-peer-site :dummy-messenger
+  [_ _] "localhost")

--- a/test/onyx/messaging/dummy_messenger.clj
+++ b/test/onyx/messaging/dummy_messenger.clj
@@ -14,5 +14,5 @@
   [messenger]
   {:address 1})
 
-(defmethod extensions/open-peer-site :dummy-messenger
+(defmethod extensions/open-peer-site :default
   [_ _] "localhost")


### PR DESCRIPTION
Sorts acker candidates, putting peers that are executing exempt tasks on the same machine latest in the candidate pool. cc @lbradstreet 