### PR TITLE
fix docs link

### DIFF
--- a/doc/user-guide/what-does-it-offer.md
+++ b/doc/user-guide/what-does-it-offer.md
@@ -50,11 +50,10 @@ Onyx uses the notion of a *sentinel value* to transparently switch between strea
 
 #### Aspect Orientation
 
-Clojure functions again serve as a huge win. [Dire](https://github.com/onyx-platform/dire) is a library that supports aspects, meaning you can keep your application logic airtight away from logging, preconditions, and error handling.
+Clojure functions again serve as a huge win. [Dire](https://github.com/MichaelDrogalis/dire) is a library that supports aspects, meaning you can keep your application logic airtight away from logging, preconditions, and error handling.
 
 #### AOT Nothing
 
 Onyx AOT's absolutely nothing on your behalf. When you're ready to stand your jar up, simply uberjar and start executing on the target machine. Hadoop and Storm cause dependency hell (In Storm's case, you're restricted to a particular version of Clojure because you're locked in by the Executor) by providing their own dependencies on top of yours. Onyx won't mess with your dependencies.
 
 You can, however, AOT Onyx yourself to speed up compilation times.
-


### PR DESCRIPTION
this is already fixed in master, but github and onyxplatform/docs default to 0.6.x, which still has a broken link.