### PR TITLE
grammar

### DIFF
--- a/doc/user-guide/architecture-low-level-design.md
+++ b/doc/user-guide/architecture-low-level-design.md
@@ -57,7 +57,7 @@ Every virtual peer maintains its own inbox and output. Messages received appear 
 
 Messages arrive in the inbox as commands are proposed into the ZooKeeper log. Technically, the inbox need only be size 1 since all log entries are processed strictly in order. As an optimization, the peer can choose to read a few extra commands behind the one it's currently processing. In practice, the inbox will probably be configured with a size greater than one.
 
-The outbox is used to send commands to the log. Certain commands processed by the peer will generate *other* commands. For example, if a peer is idle and it receives a command notifying it about a new job, the peer will *react* by sending a command to the log that it gets allocated for work. Each peer can choose to *pause* or *resume* the sending of its outbox messages. This is useful when the peer is just acquiring membership to the cluster. It will have to play log commands to join the cluster fully, but it cannot volunteer to be allocated for work since it's not officially yet a member of the cluster.
+The outbox is used to send commands to the log. Certain commands processed by the peer will generate *other* commands. For example, if a peer is idle and it receives a command notifying it about a new job, the peer will *react* by sending a command to the log requesting that it be allocated for work. Each peer can choose to *pause* or *resume* the sending of its outbox messages. This is useful when the peer is just acquiring membership to the cluster. It will have to play log commands to join the cluster fully, but it cannot volunteer to be allocated for work since it's not officially yet a member of the cluster.
 
 ### Applying Log Entries
 


### PR DESCRIPTION
changes "sending a command to the log that it gets allocated for work" to "sending a command to the log requesting that it be allocated for work"

I think this more clearly states the intended meaning?