### PR TITLE
Add timeout to take-segments! and await-job-completion

### DIFF
--- a/src/onyx/plugin/core_async.clj
+++ b/src/onyx/plugin/core_async.clj
@@ -1,6 +1,5 @@
 (ns onyx.plugin.core-async
   (:require [clojure.core.async :refer [chan >!! <!! alts!! timeout go <! alts! close!]]
-            [clojure.core.async.lab]
             [onyx.peer.function :as function]
             [onyx.peer.pipeline-extensions :as p-ext]
             [onyx.static.default-vals :refer [defaults]]


### PR DESCRIPTION
fixes #219 
For `await-job-completion` I'm not sure the argument ordering. It would be nice to be able to specify quasi-builder-style `(await-job-completion peer-config job-id :monitoring-config {:monitoring :no-op} :timeout 100)` 

But for now I decided to keep it consistent with the rest of onyx.  

P.S. if anyone knows how to stop GIT from highlighting whitespace changes, I can amend this. Emacs is not loving whatever is going on here. Cant save the file without the lines getting funky.

Thanks!