### PR TITLE
fix minor docs error on lifecycle function params

### DIFF
--- a/doc/user-guide/functions.md
+++ b/doc/user-guide/functions.md
@@ -43,11 +43,11 @@ A function can be parameterized before a job is submitted to Onyx. The segment i
 
 The function is then invoked with `(partial f :my-args-here)`.
 
-- Via the `:onyx.peer-fn-params` in the `before-task-start` lifecycle hook
+- Via the `:onyx.core/params` in the `before-task-start` lifecycle hook
 
 ```clojure
 (defn before-task-start-hook [event lifecycle]
-  {:onyx.core/fn-params [:my-args-here]})
+  {:onyx.core/params [:my-args-here]})
 ```
 
 The function is then invoked with `(partial f :my-args-here)`.


### PR DESCRIPTION
keywords for setting function params from a before-task-start lifecycle call were wrong