### PR TITLE
Make interop namespace load other namespaces lazily

### DIFF
--- a/src/onyx/interop.clj
+++ b/src/onyx/interop.clj
@@ -2,16 +2,17 @@
   (:gen-class :name onyx.interop
               :methods [^:static [write_batch [clojure.lang.IPersistentMap] clojure.lang.IPersistentMap]
                         ^:static [read_batch [clojure.lang.IPersistentMap] clojure.lang.IPersistentMap]])
-  (:require [onyx.peer.function :refer [write-batch read-batch]]
-            [onyx.peer.pipeline-extensions :refer [PipelineInput Pipeline]]))
+  (:require [onyx.peer.pipeline-extensions :refer [PipelineInput Pipeline]]))
 
 (defn -write_batch
   [event]
-  (write-batch event))
+  (require 'onyx.peer.function)
+  ((resolve 'onyx.peer.function/write-batch) event))
 
 (defn -read_batch
   [event]
-  (read-batch event))
+  (require 'onyx.peer.function)
+  ((resolve 'onyx.peer.function/read-batch) event))
 
 (gen-interface
   :name onyx.IPipelineInput


### PR DESCRIPTION
This avoids AOT compilation of complete dependency tree (including clojure.core, tools.reader...) which causes problems with projects which use other versions of these libraries.

Fixes #339

PS. I'm not using Onyx myself so I don't know how interop ns is used. I ran tests but I don't know if they test this.