### PR TITLE
Fixes for multiple scheduler bugs (issue #349)

### DIFF
--- a/src/onyx/messaging/aeron/peer_manager.clj
+++ b/src/onyx/messaging/aeron/peer_manager.clj
@@ -1,4 +1,4 @@
-(ns onyx.messaging.aeron.peer-manager
+(ns ^:no-doc onyx.messaging.aeron.peer-manager
   "Fast way for peer group subscribers to multiplex via a short id to peer channels. "
   (:refer-clojure :exclude [assoc dissoc])
   (:require [taoensso.timbre :refer [fatal info] :as timbre])

--- a/src/onyx/messaging/aeron/publication_manager.clj
+++ b/src/onyx/messaging/aeron/publication_manager.clj
@@ -1,4 +1,4 @@
-(ns onyx.messaging.aeron.publication-manager
+(ns ^:no-doc onyx.messaging.aeron.publication-manager
   (:require [taoensso.timbre :refer [error fatal info] :as timbre]
             [clojure.core.async :refer [chan >!! <!! put! close! sliding-buffer thread]])
   (:import [uk.co.real_logic.aeron Aeron Aeron$Context FragmentAssembler Publication Subscription AvailableImageHandler]

--- a/src/onyx/scheduling/balanced_job_scheduler.clj
+++ b/src/onyx/scheduling/balanced_job_scheduler.clj
@@ -59,5 +59,8 @@
   (loop [jobs* jobs n* n]
     (if (zero? n*)
       jobs*
-      (recur (update-in jobs* [(select-job-requiring-peer replica jobs*)] inc)
-             (dec n*)))))
+      (let [job (select-job-requiring-peer replica jobs*)]
+        (if job
+          (recur (update jobs* job inc)
+                 (dec n*))
+          jobs*)))))

--- a/src/onyx/scheduling/balanced_task_scheduler.clj
+++ b/src/onyx/scheduling/balanced_task_scheduler.clj
@@ -39,8 +39,7 @@
        ;; task is allowed to be allocated to, we give it one peer and rotate it
        ;; to the back to possibly get more peers later.
        (and (< (get results least-allocated-task)
-               (or (get-in replica [:task-saturation job least-allocated-task]
-                           Double/POSITIVE_INFINITY)))
+               (get-in replica [:task-saturation job least-allocated-task] Double/POSITIVE_INFINITY))
             (not (cts/preallocated-grouped-task? replica job least-allocated-task)))
        (recur task-seq (update-in results [least-allocated-task] inc) (dec capacity))
 

--- a/src/onyx/scheduling/balanced_task_scheduler.clj
+++ b/src/onyx/scheduling/balanced_task_scheduler.clj
@@ -9,7 +9,10 @@
    (reduce
     (fn [[peers-to-drop allocations] _]
       (let [max-peers (->> allocations
-                           (sort-by (comp count val))
+                           (remove (fn [[task peers]]
+                                     (= (count peers) (get-in replica [:min-required-peers job task] 1))))
+                           (sort-by (fn [[task peers]]
+                                      (count peers)))
                            reverse
                            first
                            second

--- a/src/onyx/scheduling/balanced_task_scheduler.clj
+++ b/src/onyx/scheduling/balanced_task_scheduler.clj
@@ -64,7 +64,7 @@
                (if (cts/preallocated-grouped-task? replica job task)
                  (assoc all task (count (get-in replica [:allocations job task])))
                  (assoc all task (min (get-in replica [:task-saturation job task] Double/POSITIVE_INFINITY)
-                                      (get-in replica [:min-required-peers job task] Double/POSITIVE_INFINITY)))))
+                                      (get-in replica [:min-required-peers job task] 1)))))
              {}
              (map vector tasks (range)))
             spare-peers (- n (apply + (vals init)))]

--- a/src/onyx/scheduling/common_job_scheduler.clj
+++ b/src/onyx/scheduling/common_job_scheduler.clj
@@ -37,7 +37,7 @@
                         ;; Cannot allocate anymore, you have what you have.
                         (count (get-in replica [:allocations job task]))
                         ;; Grab the absolute minimum for this task, no constraints.
-                        (get-in replica [:min-required-peers job task])))
+                        (get-in replica [:min-required-peers job task] 1)))
                     tasks))
       (apply + (vals (get-in replica [:min-required-peers job]))))))
 

--- a/src/onyx/test_helper.clj
+++ b/src/onyx/test_helper.clj
@@ -50,8 +50,8 @@
 
 (defn add-test-env-peers! 
   "Add peers to an OnyxTestEnv component"
-  [{:keys [peer-group peers] :as component} n-peers]
-  (swap! peers into (try-start-peers n-peers peer-group)))
+  [{:keys [peer-group peers monitoring-config] :as component} n-peers]
+  (swap! peers into (try-start-peers n-peers peer-group monitoring-config)))
 
 (defrecord OnyxTestEnv [env-config peer-config monitoring-config n-peers]
   component/Lifecycle

--- a/test/onyx/log/generative_peer_join.clj
+++ b/test/onyx/log/generative_peer_join.clj
@@ -292,7 +292,7 @@
             :entries (assoc (log-gen/generate-join-queues (log-gen/generate-peer-ids 6))
                             :job-1 {:queue [(api/create-submit-job-entry
                                               job-max-peers-id
-                                              peer-config
+                                              (assoc peer-config :onyx.peer/job-scheduler scheduler)
                                               job-max-peers
                                               (planning/discover-tasks (:catalog job-max-peers) (:workflow job-max-peers)))]})
             :log []
@@ -345,7 +345,7 @@
             :entries (assoc (log-gen/generate-join-queues (log-gen/generate-peer-ids 6))
                             :job-1 {:queue [(api/create-submit-job-entry
                                               job-min-peers-id
-                                              peer-config
+                                              (assoc peer-config :onyx.peer/job-scheduler scheduler)
                                               job-min-peers
                                               (planning/discover-tasks (:catalog job-min-peers) (:workflow job-min-peers)))]})
             :log []

--- a/test/onyx/log/generative_peer_join.clj
+++ b/test/onyx/log/generative_peer_join.clj
@@ -591,3 +591,100 @@
     ;; since there are enough peers to handle 2 peers leaving without a task being deallocated the
     ;; job must be able to go on
     (is (>= (apply + (map count (vals (get (:allocations replica) job-1-id)))) 7))))
+
+
+;; Reproduce onyx-test scheduler issue
+(def inner-job-id #uuid "f55c14f0-a847-42eb-81bb-0c0390a88608")
+
+(def inner-job
+  {:workflow [[:a :b] [:b :c] [:c :d] [:d :e]]
+   :catalog [{:onyx/name :a
+              :onyx/plugin :onyx.plugin.core-async/input
+              :onyx/type :input
+              :onyx/min-peers 4
+              :onyx/medium :core.async
+              :onyx/batch-size 20
+              :onyx/doc "Reads segments from a core.async channel"}
+
+             {:onyx/name :b
+              :onyx/fn :mock/fn
+              :onyx/type :function
+              :onyx/batch-size 20}
+
+             {:onyx/name :c
+              :onyx/fn :mock/fn
+              :onyx/type :function
+              :onyx/batch-size 20}
+
+             {:onyx/name :d
+              :onyx/fn :mock/fn
+              :onyx/type :function
+              :onyx/batch-size 20}
+
+             {:onyx/name :e
+              :onyx/plugin :onyx.plugin.core-async/output
+              :onyx/max-peers 1
+              :onyx/type :output
+              :onyx/medium :core.async
+              :onyx/batch-size 20
+              :onyx/doc "Writes segments to a core.async channel"}]
+   :task-scheduler :onyx.task-scheduler/balanced})
+
+(def outer-job-id #uuid "5813d2ec-c486-4428-833d-e8373910ae14")
+
+(def outer-job
+  {:workflow [[:d :e] [:e :f]]
+   :catalog [{:onyx/name :d
+              :onyx/plugin :onyx.plugin.core-async/input
+              :onyx/type :input
+              :onyx/medium :core.async
+              :onyx/batch-size 20
+              :onyx/max-peers 1
+              :onyx/doc "Reads segments from a core.async channel"}
+
+             {:onyx/name :e
+              :onyx/fn :mock/fn
+              :onyx/type :function
+              :onyx/batch-size 20}
+
+             {:onyx/name :f
+              :onyx/plugin :onyx.plugin.core-async/output
+              :onyx/type :output
+              :onyx/max-peers 1
+              :onyx/medium :core.async
+              :onyx/batch-size 20
+              :onyx/doc "Writes segments to a core.async channel"}]
+   :task-scheduler :onyx.task-scheduler/balanced})
+
+(defn running? [peer-counts]
+  (and (not (empty? peer-counts)) 
+       (not (some zero? peer-counts))))
+
+#_(deftest outer-inner-allocations
+  (checking
+    "Reproduce scheduler issue in https://github.com/littlebird/onyx-test. 
+    Second job fails to run due to cjs/job-offer-n-peers :onyx.job-scheduler/balanced"
+    (times 50)
+    [{:keys [replica log peer-choices]}
+     (log-gen/apply-entries-gen
+       (gen/return
+         {:replica {:job-scheduler :onyx.job-scheduler/balanced
+                    :messaging {:onyx.messaging/impl :dummy-messenger}}
+          :message-id 0
+          :entries (assoc (log-gen/generate-join-queues (log-gen/generate-peer-ids 11))
+                          :job-1 {:queue [(api/create-submit-job-entry
+                                            inner-job-id
+                                            peer-config
+                                            inner-job
+                                            (planning/discover-tasks (:catalog inner-job) (:workflow inner-job)))]}
+                          :job-2 {:queue [(api/create-submit-job-entry
+                                            outer-job-id
+                                            peer-config
+                                            outer-job
+                                            (planning/discover-tasks (:catalog outer-job) (:workflow outer-job)))]})
+          :log []
+          :peer-choices []}))]
+    (standard-invariants replica)
+    (is (= #{:active} (set (vals (:peer-state replica)))))
+    (is (running? (map count (vals (get (:allocations replica) inner-job-id)))))
+    (is (running? (map count (vals (get (:allocations replica) outer-job-id)))))))


### PR DESCRIPTION
Fixes multiple bugs with min-peers and max-peers handling in balanced and percentage schedulers.

Adds generative tests for these, as well as an additional, commented out, test "outer-inner-allocations", which highlights failings in the balanced scheduler which should be addressed later.