### PR TITLE
Serialize exception that killed a job to ZooKeeper

### DIFF
--- a/doc/user-guide/monitoring.md
+++ b/doc/user-guide/monitoring.md
@@ -72,6 +72,7 @@ Event name                         | Keys                             |
 `:zookeeper-write-chunk`           | `:event`, `:latency`, `:bytes`   |
 `:zookeeper-write-job-scheduler`   | `:event`, `:latency`, `:bytes`   |
 `:zookeeper-write-messaging`       | `:event`, `:latency`, `:bytes`   |
+`:zookeeper-write-exception`       | `:event`, `:latency`, `:bytes`   |
 `:zookeeper-force-write-chunk`     | `:event`, `:latency`, `:bytes`   |
 `:zookeeper-write-origin`          | `:event`, `:latency`, `:bytes`   |
 `:zookeeper-read-catalog`          | `:event`, `:latency`             |
@@ -85,6 +86,7 @@ Event name                         | Keys                             |
 `:zookeeper-read-origin`           | `:event`, `:latency`             |
 `:zookeeper-read-job-scheduler`    | `:event`, `:latency`             |
 `:zookeeper-read-messaging`        | `:event`, `:latency`             |
+`:zookeeper-read-exception`        | `:event`, `:latency`             |
 `:zookeeper-gc-log-entry`          | `:event`, `:latency`, `:position`|
 `:peer-ack-segments`               | `:event`, `:latency`             |
 `:peer-retry-segment`              | `:event`, `:latency`             |

--- a/src/onyx/log/curator.clj
+++ b/src/onyx/log/curator.clj
@@ -21,34 +21,33 @@
 ;; Thanks to zookeeper-clj
 (defn stat-to-map
   ([^org.apache.zookeeper.data.Stat stat]
-   ;;(long czxid, long mzxid, long ctime, long mtime, int version, int cversion, int aversion, long ephemeralOwner, int dataLength, int numChildren, long pzxid)
    (when stat
-     {:czxid (.getCzxid stat)
-      :mzxid (.getMzxid stat)
-      :ctime (.getCtime stat)
-      :mtime (.getMtime stat)
-      :version (.getVersion stat)
-      :cversion (.getCversion stat)
-      :aversion (.getAversion stat)
-      :ephemeralOwner (.getEphemeralOwner stat)
-      :dataLength (.getDataLength stat)
-      :numChildren (.getNumChildren stat)
-      :pzxid (.getPzxid stat)})))
+     {:czxid (.getCzxid stat) ;; long
+      :mzxid (.getMzxid stat) ;; long
+      :ctime (.getCtime stat) ;; long
+      :mtime (.getMtime stat) ;; long
+      :version (.getVersion stat) ;; int
+      :cversion (.getCversion stat) ;;  int
+      :aversion (.getAversion stat) ;; long
+      :ephemeralOwner (.getEphemeralOwner stat) ;;int
+      :dataLength (.getDataLength stat) ;; int
+      :numChildren (.getNumChildren stat) ;; int
+      :pzxid (.getPzxid stat)}))) ;; long
 
 (defn event-to-map
   ([^org.apache.zookeeper.WatchedEvent event]
-     (when event
-       {:event-type (keyword (.name (.getType event)))
-        :keeper-state (keyword (.name (.getState event)))
-        :path (.getPath event)})))
+   (when event
+     {:event-type (keyword (.name (.getType event)))
+      :keeper-state (keyword (.name (.getState event)))
+      :path (.getPath event)})))
 
 ;; Watcher
 
 (defn make-watcher
   ([handler]
-     (reify Watcher
-       (process [this event]
-         (handler (event-to-map event))))))
+   (reify Watcher
+     (process [this event]
+       (handler (event-to-map event))))))
 
 (defn ^CuratorFramework connect
   ([connection-string]
@@ -56,16 +55,16 @@
   ([connection-string ns]
    (connect connection-string ns
             (BoundedExponentialBackoffRetry.
-              (:onyx.zookeeper/backoff-base-sleep-time-ms defaults)
-              (:onyx.zookeeper/backoff-max-sleep-time-ms defaults)
-              (:onyx.zookeeper/backoff-max-retries defaults))))
+             (:onyx.zookeeper/backoff-base-sleep-time-ms defaults)
+             (:onyx.zookeeper/backoff-max-sleep-time-ms defaults)
+             (:onyx.zookeeper/backoff-max-retries defaults))))
   ([connection-string ns ^RetryPolicy retry-policy]
    (doto
-     (.. (CuratorFrameworkFactory/builder)
-         (namespace ns)
-         (connectString connection-string)
-         (retryPolicy retry-policy)
-         (build))
+       (.. (CuratorFrameworkFactory/builder)
+           (namespace ns)
+           (connectString connection-string)
+           (retryPolicy retry-policy)
+           (build))
      .start)))
 
 (defn close
@@ -87,8 +86,8 @@
   [^CuratorFramework client path & {:keys [data] :as opts}]
   (try
     (let [cr ^SetDataBuilder (.. client
-                 create
-                 (withMode (create-mode opts)))]
+                                 create
+                                 (withMode (create-mode opts)))]
       (if data
         (.forPath ^SetDataBuilder cr path data)
         (.forPath ^SetDataBuilder cr path)))
@@ -136,7 +135,7 @@
 
 (defn exists [^CuratorFramework client path & {:keys [watcher]}]
   (stat-to-map
-    (let [builder ^ExistsBuilder (.. client checkExists)]
-      (if watcher
-        (.forPath ^ExistsBuilder (.usingWatcher builder ^Watcher (make-watcher watcher)) path)
-        (.forPath builder path)))))
+   (let [builder ^ExistsBuilder (.. client checkExists)]
+     (if watcher
+       (.forPath ^ExistsBuilder (.usingWatcher builder ^Watcher (make-watcher watcher)) path)
+       (.forPath builder path)))))

--- a/src/onyx/log/zookeeper.clj
+++ b/src/onyx/log/zookeeper.clj
@@ -65,6 +65,9 @@
 (defn ledgers-available-path [prefix]
   (str (prefix-path prefix) "/ledgers/available"))
 
+(defn exception-path [prefix]
+  (str (prefix-path prefix) "/exception"))
+
 (defn throw-subscriber-closed []
   (throw (ex-info "Log subscriber closed due to disconnection from ZooKeeper" {})))
 
@@ -109,6 +112,7 @@
       (zk/create conn (origin-path onyx-id) :persistent? true)
       (zk/create conn (job-scheduler-path onyx-id) :persistent? true)
       (zk/create conn (messaging-path onyx-id) :persistent? true)
+      (zk/create conn (exception-path onyx-id) :persistent? true)
 
       (initialize-origin! conn config onyx-id)
       (assoc component :server server :conn conn :prefix onyx-id)))
@@ -393,6 +397,19 @@
                   :latency % :bytes (count bytes)}]
         (extensions/emit monitoring args)))))
 
+(defmethod extensions/write-chunk [ZooKeeper :exception]
+  [{:keys [conn opts prefix monitoring] :as log} kw chunk id]
+  (let [bytes (zookeeper-compress chunk)]
+    (measure-latency
+     #(clean-up-broken-connections
+       (fn []
+         (let [node (str (exception-path prefix) "/" id)]
+           (zk/create-all conn node :persistent? true :data bytes)
+           id)))
+     #(let [args {:event :zookeeper-write-exception :id id
+                  :latency % :bytes (count bytes)}]
+        (extensions/emit monitoring args)))))
+
 (defmethod extensions/force-write-chunk [ZooKeeper :chunk]
   [{:keys [conn opts prefix monitoring] :as log} kw chunk id]
   (let [bytes (zookeeper-compress chunk)]
@@ -516,6 +533,16 @@
        (let [node (str (messaging-path prefix) "/messaging")]
          (zookeeper-decompress (:data (zk/data conn node))))))
    #(let [args {:event :zookeeper-read-messaging :id id :latency %}]
+      (extensions/emit monitoring args))))
+
+(defmethod extensions/read-chunk [ZooKeeper :exception]
+  [{:keys [conn opts prefix monitoring] :as log} kw id & _]
+  (measure-latency
+   #(clean-up-broken-connections
+     (fn []
+       (let [node (str (exception-path prefix) "/" id)]
+         (zookeeper-decompress (:data (zk/data conn node))))))
+   #(let [args {:event :zookeeper-read-exception :id id :latency %}]
       (extensions/emit monitoring args))))
 
 (defmethod extensions/update-origin! ZooKeeper

--- a/src/onyx/monitoring/custom_monitoring.clj
+++ b/src/onyx/monitoring/custom_monitoring.clj
@@ -15,6 +15,7 @@
    zookeeper-write-chunk
    zookeeper-write-job-scheduler
    zookeeper-write-messaging
+   zookeeper-write-exception
    zookeeper-force-write-chunk
    zookeeper-write-origin
    zookeeper-read-catalog
@@ -26,6 +27,7 @@
    zookeeper-read-origin
    zookeeper-read-job-scheduler
    zookeeper-read-messaging
+   zookeeper-read-exception
    zookeeper-gc-log-entry
    window-log-write-entry
    window-log-playback

--- a/src/onyx/peer/task_lifecycle.clj
+++ b/src/onyx/peer/task_lifecycle.clj
@@ -519,11 +519,12 @@
           event
           (:onyx.core/triggers event)))
 
-(defn handle-exception [restart-pred-fn e restart-ch outbox-ch job-id]
+(defn handle-exception [log restart-pred-fn e restart-ch outbox-ch job-id]
   (warn e)
   (if (restart-pred-fn e)
     (>!! restart-ch true)
     (let [entry (entry/create-log-entry :kill-job {:job job-id})]
+      (extensions/write-chunk log :exception e job-id)
       (>!! outbox-ch entry))))
 
 (defn run-task-lifecycle
@@ -696,7 +697,7 @@
             pipeline-data (assoc pipeline-data :onyx.core/pipeline pipeline)
 
             restart-pred-fn (operation/resolve-restart-pred-fn task-map)
-            ex-f (fn [e] (handle-exception restart-pred-fn e restart-ch outbox-ch job-id))
+            ex-f (fn [e] (handle-exception log restart-pred-fn e restart-ch outbox-ch job-id))
             _ (while (and (first (alts!! [kill-ch task-kill-ch] :default true))
                           (not (munge-start-lifecycle pipeline-data)))
                 (Thread/sleep (arg-or-default :onyx.peer/peer-not-ready-back-off opts)))
@@ -735,7 +736,7 @@
                  :input-retry-segments-ch input-retry-segments-ch
                  :aux-ch aux-ch)))
       (catch Throwable e
-        (handle-exception (constantly false) e restart-ch outbox-ch job-id)
+        (handle-exception log (constantly false) e restart-ch outbox-ch job-id)
         component)))
 
   (stop [component]

--- a/test/onyx/peer/serialized_exception_test.clj
+++ b/test/onyx/peer/serialized_exception_test.clj
@@ -1,0 +1,79 @@
+(ns onyx.peer.serialized-exception-test
+  (:require [clojure.core.async :refer [chan >!! <!! close! sliding-buffer]]
+            [clojure.test :refer [deftest is testing]]
+            [onyx.plugin.core-async :refer [take-segments!]]
+            [onyx.test-helper :refer [load-config with-test-env add-test-env-peers!]]
+            [onyx.extensions :as extensions]
+            [onyx.api]))
+
+(def n-messages 100)
+
+(def in-chan (atom nil))
+
+(def out-chan (atom nil))
+
+(defn inject-in-ch [event lifecycle]
+  {:core.async/chan @in-chan})
+
+(defn inject-out-ch [event lifecycle]
+  {:core.async/chan @out-chan})
+
+(def in-calls
+  {:lifecycle/before-task-start inject-in-ch})
+
+(def out-calls
+  {:lifecycle/before-task-start inject-out-ch})
+
+(defn my-inc [{:keys [n] :as segment}]
+  (throw (ex-info "Exception message" {:exception-data 42})))
+
+(deftest min-peers-test
+  (let [id (java.util.UUID/randomUUID)
+        config (load-config)
+        env-config (assoc (:env-config config) :onyx/id id)
+        peer-config (assoc (:peer-config config) :onyx/id id)]
+    (with-test-env [test-env [3 env-config peer-config]]
+      (let [batch-size 20
+            catalog [{:onyx/name :in
+                      :onyx/plugin :onyx.plugin.core-async/input
+                      :onyx/type :input
+                      :onyx/medium :core.async
+                      :onyx/batch-size batch-size
+                      :onyx/max-peers 1
+                      :onyx/doc "Reads segments from a core.async channel"}
+
+                     {:onyx/name :inc
+                      :onyx/fn ::my-inc
+                      :onyx/type :function
+                      :onyx/batch-size batch-size}
+
+                     {:onyx/name :out
+                      :onyx/plugin :onyx.plugin.core-async/output
+                      :onyx/type :output
+                      :onyx/medium :core.async
+                      :onyx/batch-size batch-size
+                      :onyx/max-peers 1
+                      :onyx/doc "Writes segments to a core.async channel"}]
+            workflow [[:in :inc] [:inc :out]]
+            lifecycles [{:lifecycle/task :in
+                         :lifecycle/calls ::in-calls}
+                        {:lifecycle/task :in
+                         :lifecycle/calls :onyx.plugin.core-async/reader-calls}
+                        {:lifecycle/task :out
+                         :lifecycle/calls ::out-calls}
+                        {:lifecycle/task :out
+                         :lifecycle/calls :onyx.plugin.core-async/writer-calls}]
+            _ (reset! in-chan (chan (inc n-messages)))
+            _ (reset! out-chan (chan (sliding-buffer (inc n-messages))))
+            _ (doseq [n (range n-messages)]
+                (>!! @in-chan {:n n}))
+            job-id (:job-id (onyx.api/submit-job
+                             peer-config
+                             {:catalog catalog
+                              :workflow workflow
+                              :lifecycles lifecycles
+                              :task-scheduler :onyx.task-scheduler/balanced}))]
+        (onyx.api/await-job-completion peer-config job-id)
+        (let [e (extensions/read-chunk (:log (:env test-env)) :exception job-id)]
+          (is (= "Exception message" (.getMessage e)))
+          (is (= {:exception-data 42} (ex-data e))))))))


### PR DESCRIPTION
Fixes #412.

If many tasks fail at the same time, only the first one to write to ZooKeeper will win. All other tasks will fail to write their exceptions to Zookeeper, but will not raise an exception about having failed to do so. This is desired, because ultimately the first task to throw an uncaught exception kills the entire job. Waiting for all tasks to write their exceptions would take an indeterminate amount of time, thus complicating the `onyx.api/await-job-completion-api`. Hence, the job ID is used as the marker for the exception znode.