### PR TITLE
Annotate log entries with message parent and peer parent

### DIFF
--- a/src/onyx/log/commands/compact_bookkeeper_log_ids.clj
+++ b/src/onyx/log/commands/compact_bookkeeper_log_ids.clj
@@ -58,7 +58,7 @@
       (>!! (:outbox-ch state)
            {:fn :deleted-bookkeeper-log-ids
             :args {:logs delete-ids}
-            :peer-src (:id state)
-            :entry-src message-id})
+            :peer-parent (:id state)
+            :entry-parent message-id})
       (.close bk-client)))
   state)

--- a/src/onyx/log/commands/compact_bookkeeper_log_ids.clj
+++ b/src/onyx/log/commands/compact_bookkeeper_log_ids.clj
@@ -57,6 +57,8 @@
                (warn "Deleting ledger that no longer exists." e))))
       (>!! (:outbox-ch state)
            {:fn :deleted-bookkeeper-log-ids
-            :args {:logs delete-ids}})
+            :args {:logs delete-ids}
+            :peer-src (:id state)
+            :entry-src message-id})
       (.close bk-client)))
   state)

--- a/src/onyx/log/commands/leave_cluster.clj
+++ b/src/onyx/log/commands/leave_cluster.clj
@@ -72,8 +72,8 @@
                    (extensions/write-log-entry
                     (:log state)
                     {:fn :leave-cluster :args {:id (:subject updated-watch)}
-                     :entry-src message-id
-                     :peer-src (:id state)}))
+                     :entry-parent message-id
+                     :peer-parent (:id state)}))
                  (close! ch))
              (close! (or (:watch-ch state) (chan)))
              (assoc state :watch-ch ch))

--- a/src/onyx/log/commands/leave_cluster.clj
+++ b/src/onyx/log/commands/leave_cluster.clj
@@ -71,7 +71,9 @@
              (go (when (<! ch)
                    (extensions/write-log-entry
                     (:log state)
-                    {:fn :leave-cluster :args {:id (:subject updated-watch)}}))
+                    {:fn :leave-cluster :args {:id (:subject updated-watch)}
+                     :entry-src message-id
+                     :peer-src (:id state)}))
                  (close! ch))
              (close! (or (:watch-ch state) (chan)))
              (assoc state :watch-ch ch))

--- a/src/onyx/log/commands/notify_join_cluster.clj
+++ b/src/onyx/log/commands/notify_join_cluster.clj
@@ -45,8 +45,8 @@
             (extensions/write-log-entry
              (:log state)
              {:fn :leave-cluster :args {:id (:subject diff)}
-              :entry-src message-id
-              :peer-src (:id state)}))
+              :entry-parent message-id
+              :peer-parent (:id state)}))
           (close! ch))
       (close! (or (:watch-ch state) (chan)))
       (let [result-state (assoc state :watch-ch ch)]

--- a/src/onyx/log/commands/prepare_join_cluster.clj
+++ b/src/onyx/log/commands/prepare_join_cluster.clj
@@ -76,7 +76,7 @@
                               (:observer diff))}}]))
 
 (s/defmethod extensions/fire-side-effects! :prepare-join-cluster :- State
-  [{:keys [args]} :- LogEntry old new diff {:keys [monitoring] :as state}]
+  [{:keys [args message-id]} :- LogEntry old new diff {:keys [monitoring] :as state}]
   (common/start-new-lifecycle
    old new diff
    (cond (= (:id state) (:observer diff))
@@ -86,7 +86,9 @@
            (go (when (<! ch)
                  (extensions/write-log-entry
                   (:log state)
-                  {:fn :leave-cluster :args {:id (:subject diff)}}))
+                  {:fn :leave-cluster :args {:id (:subject diff)}
+                   :peer-src (:id state)
+                   :entry-src message-id}))
                (close! ch))
            (assoc state :watch-ch ch))
          ;; Handles the cases where a peer tries to attach to a dead
@@ -96,7 +98,9 @@
            (do
              (extensions/write-log-entry
               (:log state)
-              {:fn :leave-cluster :args {:id (:observer diff)}})
+              {:fn :leave-cluster :args {:id (:observer diff)}
+               :peer-src (:id state)
+               :entry-src message-id})
              state)
            (let [fd (failure-detector (:log state) (:observer diff) (:opts state))]
              (assoc state :failure-detector (component/start fd))))

--- a/src/onyx/log/commands/prepare_join_cluster.clj
+++ b/src/onyx/log/commands/prepare_join_cluster.clj
@@ -99,8 +99,7 @@
              (extensions/write-log-entry
               (:log state)
               {:fn :leave-cluster :args {:id (:observer diff)}
-               :peer-src (:id state)
-               :entry-src message-id})
+               :peer-src (:id state)})
              state)
            (let [fd (failure-detector (:log state) (:observer diff) (:opts state))]
              (assoc state :failure-detector (component/start fd))))

--- a/src/onyx/log/commands/prepare_join_cluster.clj
+++ b/src/onyx/log/commands/prepare_join_cluster.clj
@@ -87,8 +87,8 @@
                  (extensions/write-log-entry
                   (:log state)
                   {:fn :leave-cluster :args {:id (:subject diff)}
-                   :peer-src (:id state)
-                   :entry-src message-id}))
+                   :peer-parent (:id state)
+                   :entry-parent message-id}))
                (close! ch))
            (assoc state :watch-ch ch))
          ;; Handles the cases where a peer tries to attach to a dead
@@ -99,7 +99,7 @@
              (extensions/write-log-entry
               (:log state)
               {:fn :leave-cluster :args {:id (:observer diff)}
-               :peer-src (:id state)})
+               :peer-parent (:id state)})
              state)
            (let [fd (failure-detector (:log state) (:observer diff) (:opts state))]
              (assoc state :failure-detector (component/start fd))))

--- a/src/onyx/log/failure_detector.clj
+++ b/src/onyx/log/failure_detector.clj
@@ -21,7 +21,8 @@
             (cond (and (= ch t-ch) (not (extensions/peer-exists? log peer-id)))
                   (extensions/write-log-entry
                    log
-                   {:fn :leave-cluster :args {:id peer-id}})
+                   {:fn :leave-cluster :args {:id peer-id}
+                    :peer-src peer-id})
 
                   (= ch t-ch)
                   (recur)))))

--- a/src/onyx/log/failure_detector.clj
+++ b/src/onyx/log/failure_detector.clj
@@ -22,7 +22,7 @@
                   (extensions/write-log-entry
                    log
                    {:fn :leave-cluster :args {:id peer-id}
-                    :peer-src peer-id})
+                    :peer-parent peer-id})
 
                   (= ch t-ch)
                   (recur)))))

--- a/src/onyx/peer/virtual_peer.clj
+++ b/src/onyx/peer/virtual_peer.clj
@@ -13,12 +13,12 @@
   state)
 
 (defn annotate-reaction [{:keys [message-id]} id entry]
-  (let [peer-annotated (assoc entry :peer-src id)]
+  (let [peer-annotated (assoc entry :peer-parent id)]
     ;; Not all messages are derived from other messages.
     ;; For instance, :prepare-join-cluster is a "root"
     ;; message.
     (if message-id
-      (assoc peer-annotated :entry-src message-id)
+      (assoc peer-annotated :entry-parent message-id)
       peer-annotated)))
 
 (defn processing-loop [id log messenger origin inbox-ch outbox-ch restart-ch kill-ch completion-ch opts monitoring task-component-fn]

--- a/src/onyx/peer/virtual_peer.clj
+++ b/src/onyx/peer/virtual_peer.clj
@@ -12,6 +12,9 @@
     (clojure.core.async/>!! outbox-ch reaction))
   state)
 
+(defn annotate-reaction [{:keys [message-id]} id entry]
+  (assoc entry :entry-src (:message-id entry) :peer-src id))
+
 (defn processing-loop [id log messenger origin inbox-ch outbox-ch restart-ch kill-ch completion-ch opts monitoring task-component-fn]
   (try
     (let [replica-atom (atom nil)
@@ -45,10 +48,11 @@
                   diff (extensions/replica-diff entry replica new-replica)
                   reactions (extensions/reactions entry replica new-replica diff state)
                   new-peer-view (extensions/peer-replica-view log entry replica new-replica peer-view diff state opts)
-                  new-state (extensions/fire-side-effects! entry replica new-replica diff state)]
+                  new-state (extensions/fire-side-effects! entry replica new-replica diff state)
+                  annotated-reactions (map (partial annotate-reaction entry id) reactions)]
               (reset! replica-atom new-replica)
               (reset! peer-view-atom new-peer-view)
-              (recur (send-to-outbox new-state reactions)))))))
+              (recur (send-to-outbox new-state annotated-reactions)))))))
     (catch Throwable e
       (taoensso.timbre/error e (str e) "Error in processing loop. Restarting.")
       (close! restart-ch))

--- a/src/onyx/peer/virtual_peer.clj
+++ b/src/onyx/peer/virtual_peer.clj
@@ -13,7 +13,13 @@
   state)
 
 (defn annotate-reaction [{:keys [message-id]} id entry]
-  (assoc entry :entry-src (:message-id entry) :peer-src id))
+  (let [peer-annotated (assoc entry :peer-src id)]
+    ;; Not all messages are derived from other messages.
+    ;; For instance, :prepare-join-cluster is a "root"
+    ;; message.
+    (if message-id
+      (assoc peer-annotated :entry-src message-id)
+      peer-annotated)))
 
 (defn processing-loop [id log messenger origin inbox-ch outbox-ch restart-ch kill-ch completion-ch opts monitoring task-component-fn]
   (try

--- a/src/onyx/schema.cljc
+++ b/src/onyx/schema.cljc
@@ -464,7 +464,9 @@
   {:fn s/Keyword
    :args {s/Any s/Any}
    (s/optional-key :message-id) s/Int
-   (s/optional-key :created-at) s/Int})
+   (s/optional-key :created-at) s/Int
+   (s/optional-key :peer-src) s/Uuid
+   (s/optional-key :entry-src) s/Int})
 
 (def Reactions 
   (s/maybe [LogEntry]))

--- a/src/onyx/schema.cljc
+++ b/src/onyx/schema.cljc
@@ -465,8 +465,8 @@
    :args {s/Any s/Any}
    (s/optional-key :message-id) s/Int
    (s/optional-key :created-at) s/Int
-   (s/optional-key :peer-src) s/Uuid
-   (s/optional-key :entry-src) s/Int})
+   (s/optional-key :peer-parent) s/Uuid
+   (s/optional-key :entry-parent) s/Int})
 
 (def Reactions 
   (s/maybe [LogEntry]))


### PR DESCRIPTION
Patch for #453.

@lbradstreet - I started this by annotating the message IDs as discussed. I haven't supplied a fix yet, but this is a good starting point for reference.