### PR TITLE
Allow Double values as window key

### DIFF
--- a/src/onyx/windowing/units.clj
+++ b/src/onyx/windowing/units.clj
@@ -106,3 +106,8 @@
   ICoerceKey
   (coerce-key [this units]
     (to-standard-units this units)))
+
+(extend-type java.lang.Double
+  ICoerceKey
+  (coerce-key [this units]
+    (to-standard-units this units)))

--- a/test/onyx/windowing/trigger_watermark_test.clj
+++ b/test/onyx/windowing/trigger_watermark_test.clj
@@ -38,4 +38,22 @@
     (is
      (not
       (api/trigger-fire? event trigger {:window window :segment segment
-                                        :upper-extent (inc t)})))))
+                                        :upper-extent (inc t)}))))
+
+  (let [n 1.0
+        window {:window/id :collect-segments
+                :window/task :identity
+                :window/type :global
+                :window/aggregation :onyx.windowing.aggregation/count
+                :window/window-key :double-number}
+        trigger {:trigger/window-id :collect-segments
+                 :trigger/refinement :accumulating
+                 :trigger/on :watermark
+                 :trigger/sync ::no-op
+                 :trigger/id :trigger-id}
+        segment {:double-number n}
+        event {}]
+    (is
+      (not
+        (api/trigger-fire? event trigger {:window window :segment segment
+                                          :upper-extent (inc n)})))))


### PR DESCRIPTION
Using Doubles as window key caused an exception:

```
java.lang.IllegalArgumentException: No implementation of method: :coerce-key of protocol: #'onyx.windowing.units/ICoerceKey found for class: java.lang.Double
```