### PR TITLE
Fix anchor link in functions.md

### DIFF
--- a/doc/user-guide/functions.md
+++ b/doc/user-guide/functions.md
@@ -8,7 +8,7 @@ This section outlines how Onyx programs execute behavior. Onyx uses plain Clojur
 
 - [Functional Transformation](#functional-transformation)
 - [Function Parameterization](#function-parameterization)
-- [Grouping & Aggregation](#grouping-&-aggregation)
+- [Grouping & Aggregation](#grouping-aggregation)
 - [Group By Key](#group-by-key)
 - [Group By Function](#group-by-function)
 - [Flux Policies](#flux-policies)


### PR DESCRIPTION
This fixes the hyperlink to the anchor to the "Grouping & Aggregation" section.