### PR TITLE
Perform java version validation above onyx.api ns

### DIFF
--- a/src/onyx/api.clj
+++ b/src/onyx/api.clj
@@ -1,3 +1,11 @@
+(let [min-version "1.8"
+      version (System/getProperty "java.vm.specification.version")] 
+  (when-not (or (= version min-version) 
+                (pos? (.compareTo version min-version)))
+    (throw (ex-info (format "Onyx is only supported when running on Java %s or later." min-version) 
+                    {:min-version min-version
+                     :version version}))))
+
 (ns onyx.api
   (:require [clojure.core.async :refer [chan >!! <!! close! alts!! timeout go promise-chan]]
             [com.stuartsierra.component :as component]
@@ -299,7 +307,6 @@
   ([n {:keys [config] :as peer-group} monitoring-config]
    (when-not (= (type peer-group) onyx.system.OnyxPeerGroup)
      (throw (Exception. (str "start-peers must supplied with a peer-group not a " (type peer-group)))))
-   (validator/validate-java-version)
    (doall
     (map
      (fn [_]
@@ -347,7 +354,6 @@
 (defn ^{:added "0.6.0"} start-peer-group
   "Starts a peer group for use in cases where an env is not started (e.g. distributed mode)"
   [peer-config]
-  (validator/validate-java-version)
   (validator/validate-peer-config peer-config)
   (component/start (system/onyx-peer-group peer-config)))
 

--- a/src/onyx/static/validation.clj
+++ b/src/onyx/static/validation.clj
@@ -8,12 +8,6 @@
             [onyx.schema :refer [TaskMap Catalog Workflow Job LifecycleCall StateAggregationCall
                                  Lifecycle EnvConfig PeerConfig FlowCondition]]))
 
-(defn validate-java-version []
-  (let [version (System/getProperty "java.runtime.version")] 
-    (when-not (pos? (.compareTo version "1.8.0"))
-      (throw (ex-info "Onyx is only supported when running on Java 8 or later." 
-                      {:version version})))))
-
 (defn name-and-type-not-equal [entry]
   (when (= (:onyx/name entry) (:onyx/type entry))
     (throw (ex-info "Task's :onyx/name and :onyx/type cannot be equal" {:task entry}))))


### PR DESCRIPTION
This allows us to perform a check without resorting to dynamic loading
of aeron messaging, which actually causes a number of painful delayed
error messages.