### PR TITLE
Boot out dead peers when the replica doesn't reflect the cluster state.

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,6 @@
+#### 0.8.10
+- Bug fix: fix peer join issue which occurs when cluster is in a stuck state, and dead peers need to be evicted.
+
 #### 0.8.9
 
 - **Breaking change**: Removed `:onyx/restart-pred-fn` feature, which has been deprecated in favor of the new `:lifecycle/handle-exception` feature.


### PR DESCRIPTION
@lbradstreet Up for review. We should reproduce this one before adding a patch, as you said.