### PR TITLE
No need to assoc workflow to job.

### DIFF
--- a/src/onyx/api.clj
+++ b/src/onyx/api.clj
@@ -152,7 +152,7 @@
    (submit-job peer-config job {:monitoring :no-op}))
   ([peer-config job monitoring-config]
    (try (validator/validate-peer-config peer-config)
-        (validator/validate-job (assoc job :workflow (:workflow job)))
+        (validator/validate-job job)
         (validator/validate-flow-conditions (:flow-conditions job) (:workflow job))
         (validator/validate-lifecycles (:lifecycles job) (:catalog job))
         (validator/validate-windows (:windows job) (:catalog job))


### PR DESCRIPTION
Since every job should have the key `:workflow`.