### PR TITLE
Apply fn exceptions

### DIFF
--- a/doc/user-guide/lifecycles.md
+++ b/doc/user-guide/lifecycles.md
@@ -48,7 +48,7 @@ A function that takes four arguments - an event map, a message id, the return of
 
 #### Handle Exception
 
-If an exception is thrown during any lifecycle execution except `after-task-stop`, one or more lifecycle handlers may be defined. If present, the exception will be caught and passed to this function,  which takes 4 arguments - an event map, the matching lifecycle map, the keyword lifecycle name from which the exception was thrown, and the exception object. This function must return `true` or `false` indicating whether the job should be restarted. If any exception handling function defined for this task returns `false`, the job is killed. The lifecycle that is provided to the exception will be one of the standard ones defined here - plus a few extras that are intentionally *not* definable: `:lifecycle/read-batch`, `:lifecycle/write-batch`, `:lifecycle/execute-flow-conditions`.
+If an exception is thrown during any lifecycle execution except `after-task-stop`, one or more lifecycle handlers may be defined. If present, the exception will be caught and passed to this function,  which takes 4 arguments - an event map, the matching lifecycle map, the keyword lifecycle name from which the exception was thrown, and the exception object. This function must return `true` or `false` indicating whether the job should be restarted. If any exception handling function defined for this task returns `false`, the job is killed. The lifecycle that is provided to the exception will be one of the standard ones defined here - plus a few extras that are intentionally *not* definable: `:lifecycle/read-batch`, `:lifecycle/write-batch`, `:lifecycle/execute-flow-conditions`, and `:lifecycle/apply-fn`.
 
 ### Example
 

--- a/src/onyx/flow_conditions/fc_routing.clj
+++ b/src/onyx/flow_conditions/fc_routing.clj
@@ -1,5 +1,6 @@
 (ns onyx.flow-conditions.fc-routing
   (:require [onyx.peer.operation :as operation]
+            [onyx.lifecycles.lifecycle-invoke :as lc]
             [taoensso.timbre :refer [info error warn trace fatal] :as timbre]
             [onyx.types :refer [->Route]]))
 
@@ -37,7 +38,9 @@
   [event {:keys [egress-ids compiled-ex-fcs compiled-norm-fcs flow-conditions] :as compiled} result message]
   (if (nil? flow-conditions)
     (if (operation/exception? message)
-      (throw (:exception (ex-data message)))
+      (let [e (:exception (ex-data message))]
+        (lc/handle-exception
+         event :lifecycle/apply-fn e (:compiled-handle-exception-fn compiled)))
       (->Route egress-ids nil nil nil))
     (if (operation/exception? message)
       (if (seq compiled-ex-fcs)

--- a/test/onyx/flow_conditions/flow_conditions_gen_test.clj
+++ b/test/onyx/flow_conditions/flow_conditions_gen_test.clj
@@ -99,7 +99,9 @@
   (let [e (ex-info "hih" {})
         wrapped-e (ex-info "" {:exception e})]
     (is (thrown? clojure.lang.ExceptionInfo
-                 (r/route-data {} {:flow-conditions nil :egress-ids [:a :b]} nil wrapped-e)))))
+                 (r/route-data {} 
+                               {:compiled-handle-exception-fn (constantly :restart)
+                                :flow-conditions nil :egress-ids [:a :b]} nil wrapped-e)))))
 
 (deftest conj-downstream-tasks-together
   (checking

--- a/test/onyx/peer/apply_fn_exception_test.clj
+++ b/test/onyx/peer/apply_fn_exception_test.clj
@@ -1,0 +1,94 @@
+(ns onyx.peer.apply-fn-exception-test
+  (:require [clojure.core.async :refer [chan >!! <!! close! sliding-buffer]]
+            [clojure.test :refer [deftest is testing]]
+            [onyx.plugin.core-async :refer [take-segments!]]
+            [onyx.test-helper :refer [load-config with-test-env add-test-env-peers!]]
+            [onyx.api]))
+
+(def n-messages 100)
+
+(def in-chan (atom nil))
+
+(def out-chan (atom nil))
+
+(def handled-exception? (atom false))
+
+(defn inject-in-ch [event lifecycle]
+  {:core.async/chan @in-chan})
+
+(defn inject-out-ch [event lifecycle]
+  {:core.async/chan @out-chan})
+
+(defn handle-exception [event lifecycle phase e]
+  (reset! handled-exception? true)
+  :kill)
+
+(def in-calls
+  {:lifecycle/before-task-start inject-in-ch})
+
+(def exception-calls
+  {:lifecycle/handle-exception handle-exception})
+
+(def out-calls
+  {:lifecycle/before-task-start inject-out-ch})
+
+(defn my-inc [{:keys [n] :as segment}]
+  (throw (ex-info "Throwing from a user function" {})))
+
+(deftest flow-conditions-exception-test
+  (let [id (java.util.UUID/randomUUID)
+        config (load-config)
+        env-config (assoc (:env-config config) :onyx/tenancy-id id)
+        peer-config (assoc (:peer-config config) :onyx/tenancy-id id)]
+    (with-test-env [test-env [3 env-config peer-config]]
+      (let [batch-size 20
+            catalog [{:onyx/name :in
+                      :onyx/plugin :onyx.plugin.core-async/input
+                      :onyx/type :input
+                      :onyx/medium :core.async
+                      :onyx/batch-size batch-size
+                      :onyx/max-peers 1
+                      :onyx/doc "Reads segments from a core.async channel"}
+
+                     {:onyx/name :inc
+                      :onyx/fn ::my-inc
+                      :onyx/type :function
+                      :onyx/batch-size batch-size}
+
+                     {:onyx/name :out
+                      :onyx/plugin :onyx.plugin.core-async/output
+                      :onyx/type :output
+                      :onyx/medium :core.async
+                      :onyx/batch-size batch-size
+                      :onyx/max-peers 1
+                      :onyx/doc "Writes segments to a core.async channel"}]
+            workflow [[:in :inc] [:inc :out]]
+            lifecycles [{:lifecycle/task :in
+                         :lifecycle/calls ::in-calls}
+
+                        {:lifecycle/task :in
+                         :lifecycle/calls :onyx.plugin.core-async/reader-calls}
+
+                        {:lifecycle/task :inc
+                         :lifecycle/calls ::exception-calls}
+
+                        {:lifecycle/task :out
+                         :lifecycle/calls ::out-calls}
+
+                        {:lifecycle/task :out
+                         :lifecycle/calls :onyx.plugin.core-async/writer-calls}]
+            _ (reset! in-chan (chan (inc n-messages)))
+            _ (reset! out-chan (chan (sliding-buffer (inc n-messages))))
+            _ (doseq [n (range n-messages)]
+                (>!! @in-chan {:n n}))
+            _ (>!! @in-chan :done)
+            _ (close! @in-chan)
+            {:keys [job-id]}
+            (onyx.api/submit-job peer-config
+                                 {:catalog catalog
+                                  :workflow workflow
+                                  :lifecycles lifecycles
+                                  :task-scheduler :onyx.task-scheduler/balanced
+                                  :metadata {:job-name :click-stream}})]
+        (onyx.api/await-job-completion peer-config job-id)
+        (is @handled-exception?)))))


### PR DESCRIPTION
Solves #534, lifecycles can catch apply-fn exceptions. See Slack for explanation of the extra test. @lbradstreet 