### PR TITLE
Merge schema between user-defined schema and core

### DIFF
--- a/src/onyx/job.clj
+++ b/src/onyx/job.clj
@@ -2,11 +2,19 @@
   (:require [schema.core :as s]
             [onyx.schema :as os]))
 
+(def base-schemas
+  {:task-map os/TaskMap
+   :lifecycles [os/Lifecycle]
+   :triggers [os/Trigger]
+   :windows [os/Window]
+   :flow-conditions [os/FlowCondition]})
+
 (s/defn ^:always-validate add-task :- os/Job
   "Adds a task's task-definition to a job"
   [{:keys [lifecycles triggers windows flow-conditions] :as job}
    {:keys [task schema] :as task-definition}]
-  (when schema (s/validate schema task))
+  (merge-with s/validate schema task)
+  (merge-with s/validate base-schemas task)
   (cond-> job
     true (update :catalog conj (:task-map task))
     lifecycles (update :lifecycles into (:lifecycles task))


### PR DESCRIPTION
This PR is to make it so that users of task bundles dont have to supply the `base-schemas`.