### PR TITLE
Implement more fine grained trigger signals e.g. :job-completed

### DIFF
--- a/src/onyx/log/commands/accept_join_cluster.clj
+++ b/src/onyx/log/commands/accept_join_cluster.clj
@@ -66,5 +66,5 @@
     (extensions/emit monitoring {:event :peer-accept-join :id (:id state)}))
   (if-not (= old new)
     (do (register-acker state diff new)
-        (common/start-new-lifecycle old new diff state))
+        (common/start-new-lifecycle old new diff state :peer-reallocated))
     state))

--- a/src/onyx/log/commands/kill_job.clj
+++ b/src/onyx/log/commands/kill_job.clj
@@ -44,4 +44,4 @@
 
 (s/defmethod extensions/fire-side-effects! :kill-job :- State
   [{:keys [args]} old new diff state]
-  (common/start-new-lifecycle old new diff state))
+  (common/start-new-lifecycle old new diff state :job-killed))

--- a/src/onyx/log/commands/leave_cluster.clj
+++ b/src/onyx/log/commands/leave_cluster.clj
@@ -87,4 +87,5 @@
                 (close! (or (:watch-ch state) (chan)))
                 (assoc state :watch-ch ch))
 
-              :else state)))))
+              :else state)
+        :peer-left))))

--- a/src/onyx/log/commands/seal_output.clj
+++ b/src/onyx/log/commands/seal_output.clj
@@ -45,4 +45,4 @@
 
 (s/defmethod extensions/fire-side-effects! :seal-output :- State
   [{:keys [args]} old new diff state]
-  (common/start-new-lifecycle old new diff state))
+  (common/start-new-lifecycle old new diff state :job-completed))

--- a/src/onyx/log/commands/submit_job.clj
+++ b/src/onyx/log/commands/submit_job.clj
@@ -72,4 +72,4 @@
 
 (s/defmethod extensions/fire-side-effects! :submit-job :- State
   [entry old new diff state]
-  (common/start-new-lifecycle old new diff state))
+  (common/start-new-lifecycle old new diff state :peer-reallocated))

--- a/src/onyx/peer/task_lifecycle.clj
+++ b/src/onyx/peer/task_lifecycle.clj
@@ -419,7 +419,7 @@
 
 (defrecord TaskLifeCycle
     [id log messenger-buffer messenger job-id task-id replica peer-replica-view restart-ch log-prefix
-     kill-ch outbox-ch seal-ch completion-ch opts task-kill-ch task-monitoring task-information]
+     kill-ch outbox-ch seal-ch completion-ch opts task-kill-ch scheduler-event task-monitoring task-information]
   component/Lifecycle
 
   (start [component]
@@ -530,7 +530,7 @@
 
     (when-let [event (:pipeline-data component)]
       (when-not (empty? (:onyx.core/triggers event))
-        (>!! (:onyx.core/state-ch event) [:task-lifecycle-stopped event #()]))
+        (>!! (:onyx.core/state-ch event) [(:scheduler-event component) event #()]))
 
       (stop-window-state-thread! event)
 

--- a/src/onyx/schema.cljc
+++ b/src/onyx/schema.cljc
@@ -373,7 +373,17 @@
     :apply-state-update Function}
    record? 'record?))
 
-(def StateEvent s/Any)
+
+(def PeerSchedulerEventTypes [:peer-reallocated :peer-left :job-killed :job-completed])
+
+(def PeerSchedulerEvent (apply s/enum PeerSchedulerEventTypes))
+
+(def TriggerEventTypes [:timer-tick :new-segment])
+
+(def TriggerEvent (apply s/enum (into PeerSchedulerEventTypes TriggerEventTypes)))
+
+(def StateEvent {:event-type TriggerEvent
+                 s/Any s/Any})
 
 (def WindowState
   (s/constrained
@@ -381,7 +391,7 @@
     :trigger-states [TriggerState]
     :window Window
     :state {s/Any s/Any}
-    :state-event StateEvent
+    :state-event (s/maybe StateEvent)
     :event-results [StateEvent]
     :init-fn Function
     :create-state-update Function

--- a/src/onyx/triggers.clj
+++ b/src/onyx/triggers.clj
@@ -64,7 +64,7 @@
    {:keys [fire-time] :as state} :- TimerState
    {:keys [event-type] :as trigger-event}]
   (let [fire? (or (> (System/currentTimeMillis) fire-time)
-                  (boolean (#{:task-lifecycle-stopped} event-type)))] 
+                  (boolean (#{:job-completed} event-type)))] 
     {:fire? fire?
      :fire-time (if fire? (next-fire-time trigger) fire-time)}))
 
@@ -94,7 +94,7 @@
    {:keys [event-type] :as trigger-event}]
   (or (and (= event-type :new-segment) 
            (= trigger-state (first threshold)))
-      (= event-type :task-lifecycle-stopped)))
+      (= event-type :job-completed)))
 
 (s/defn timer-fire?
   [{:keys [trigger/period]} :- Trigger state :- TimerState {:keys [event-type] :as trigger-event}]
@@ -109,14 +109,14 @@
   ;; If this was stimulated by a new segment, check if it should fire.
   ;; Otherwise if this was a completed task, always fire.
   (or (and segment (exceeds-watermark? window upper-bound segment))
-      (= event-type :task-lifecycle-stopped)))
+      (= event-type :job-completed)))
 
 (s/defn percentile-watermark-fire? 
   [trigger :- Trigger trigger-state {:keys [lower-bound upper-bound event-type segment window]} :- StateEvent]
   ;; If this was stimulated by a new segment, check if it should fire.
   ;; Otherwise if this was a completed task, always fire.
   (or (and segment (exceeds-percentile-watermark? window trigger lower-bound upper-bound segment))
-      (= event-type :task-lifecycle-stopped)))
+      (= event-type :job-completed)))
 
 ;;; Top level vars to bundle the functions together
 (def segment

--- a/test/onyx/windowing/aggregation_average_test.clj
+++ b/test/onyx/windowing/aggregation_average_test.clj
@@ -29,7 +29,7 @@
 (def test-state (atom []))
 
 (defn update-atom! [event window trigger {:keys [lower-bound upper-bound event-type] :as opts} extent-state]
-  (when-not (= :task-lifecycle-stopped event-type)
+  (when-not (= :job-completed event-type)
     (swap! test-state conj [lower-bound upper-bound extent-state])))
 
 (def in-chan (atom nil))

--- a/test/onyx/windowing/aggregation_conj_test.clj
+++ b/test/onyx/windowing/aggregation_conj_test.clj
@@ -71,7 +71,7 @@
 (def test-state (atom []))
 
 (defn update-atom! [event window trigger {:keys [lower-bound upper-bound event-type] :as state-event} extent-state]
-  (when-not (= :task-lifecycle-stopped event-type)
+  (when-not (= :job-completed event-type)
     (swap! test-state conj [lower-bound upper-bound extent-state])))
 
 (def in-chan (atom nil))

--- a/test/onyx/windowing/aggregation_count_test.clj
+++ b/test/onyx/windowing/aggregation_count_test.clj
@@ -34,7 +34,7 @@
 (def test-state (atom []))
 
 (defn update-atom! [event window trigger {:keys [lower-bound upper-bound event-type] :as opts} extent-state]
-  (when-not (= :task-lifecycle-stopped event-type)
+  (when-not (= :job-completed event-type)
     (swap! test-state conj [(java.util.Date. lower-bound)
                             (java.util.Date. upper-bound)
                             extent-state])))

--- a/test/onyx/windowing/aggregation_max_test.clj
+++ b/test/onyx/windowing/aggregation_max_test.clj
@@ -28,7 +28,7 @@
 (def test-state (atom []))
 
 (defn update-atom! [event window trigger {:keys [lower-bound upper-bound event-type] :as opts} extent-state]
-  (when-not (= :task-lifecycle-stopped event-type)
+  (when-not (= :job-completed event-type)
     (swap! test-state conj [lower-bound upper-bound extent-state])))
 
 (def in-chan (atom nil))

--- a/test/onyx/windowing/aggregation_min_test.clj
+++ b/test/onyx/windowing/aggregation_min_test.clj
@@ -29,7 +29,7 @@
 (def test-state (atom []))
 
 (defn update-atom! [event window trigger {:keys [lower-bound upper-bound event-type] :as opts} extent-state]
-  (when-not (= :task-lifecycle-stopped event-type)
+  (when-not (= :job-completed event-type)
     (swap! test-state conj [lower-bound upper-bound extent-state])))
 
 (def in-chan (atom nil))

--- a/test/onyx/windowing/basic_windowing_crash_test.clj
+++ b/test/onyx/windowing/basic_windowing_crash_test.clj
@@ -125,7 +125,7 @@
   (def test-state (atom []))
 
   (defn update-atom! [event window trigger {:keys [lower-bound upper-bound group-key event-type] :as opts} extent-state]
-    (when-not (= :task-lifecycle-stopped event-type)
+    (when-not (= :job-completed event-type)
       (swap! test-state conj [[lower-bound upper-bound] group-key extent-state])))
 
   (def batch-num (atom 0))

--- a/test/onyx/windowing/window_fixed_test.clj
+++ b/test/onyx/windowing/window_fixed_test.clj
@@ -41,7 +41,7 @@
 (def test-state (atom []))
 
 (defn update-atom! [event window trigger {:keys [lower-bound upper-bound event-type] :as opts} extent-state]
-  (when-not (= :task-lifecycle-stopped event-type)
+  (when-not (= :job-completed event-type)
     (swap! test-state conj [lower-bound upper-bound extent-state]))) 
 
 (def in-chan (atom nil))

--- a/test/onyx/windowing/window_global_test.clj
+++ b/test/onyx/windowing/window_global_test.clj
@@ -27,7 +27,7 @@
 (def test-state (atom []))
 
 (defn update-atom! [event window trigger {:keys [lower-bound upper-bound event-type] :as opts} extent-state]
-  (when-not (= :task-lifecycle-stopped event-type)
+  (when-not (= :job-completed event-type)
     (when (swap! test-state conj [lower-bound upper-bound extent-state]))))
 
 (def in-chan (atom nil))

--- a/test/onyx/windowing/window_session_merge_test.clj
+++ b/test/onyx/windowing/window_session_merge_test.clj
@@ -61,7 +61,7 @@
 (def test-state (atom []))
 
 (defn update-atom! [event window trigger {:keys [lower-bound upper-bound event-type group-key] :as opts} extent-state]
-  (when-not (= :task-lifecycle-stopped event-type)
+  (when-not (= :job-completed event-type)
     (swap! test-state conj [(java.util.Date. lower-bound)
                             (java.util.Date. upper-bound)
                             {group-key extent-state}])))

--- a/test/onyx/windowing/window_session_test.clj
+++ b/test/onyx/windowing/window_session_test.clj
@@ -61,7 +61,7 @@
 (def test-state (atom []))
 
 (defn update-atom! [event window trigger {:keys [lower-bound upper-bound event-type] :as opts} extent-state]
-  (when-not (= :task-lifecycle-stopped event-type)
+  (when-not (= :job-completed event-type)
     (swap! test-state conj [(java.util.Date. lower-bound)
                             (java.util.Date. upper-bound)
                             extent-state])))

--- a/test/onyx/windowing/window_sliding_test.clj
+++ b/test/onyx/windowing/window_sliding_test.clj
@@ -66,7 +66,7 @@
 (def test-state (atom []))
 
 (defn update-atom! [event window trigger {:keys [lower-bound upper-bound event-type] :as opts} extent-state]
-  (when-not (= :task-lifecycle-stopped event-type)
+  (when-not (= :job-completed event-type)
     (swap! test-state conj [(java.util.Date. lower-bound)
                             (java.util.Date. upper-bound)
                             extent-state])))


### PR DESCRIPTION
This implements better trigger event types and schema checks for them. Triggers and sync fns can now tell whether the event results from job completion, peer scheduling, etc.

No changes to information_model.cljc are required, but we should probably have a way to link stuff like types taken by functions to our schemas.