### PR TITLE
Allow for blank task-map

### DIFF
--- a/src/onyx/job.clj
+++ b/src/onyx/job.clj
@@ -11,12 +11,12 @@
 
 (s/defn ^:always-validate add-task :- os/Job
   "Adds a task's task-definition to a job"
-  [{:keys [lifecycles triggers windows flow-conditions] :as job}
+  [{:keys [task-map lifecycles triggers windows flow-conditions] :as job}
    {:keys [task schema] :as task-definition}]
   (merge-with s/validate schema task)
   (merge-with s/validate base-schemas task)
   (cond-> job
-    true (update :catalog conj (:task-map task))
+    task-map (update :catalog conj (:task-map task))
     lifecycles (update :lifecycles into (:lifecycles task))
     triggers (update :triggers into (:triggers task))
     windows (update :windows into (:windows task))


### PR DESCRIPTION
Sometimes `:task-map` might be empty (i.e. for a task that's just routing).