### PR TITLE
Only write out one exhausted-input per peer, fixes #493

### DIFF
--- a/src/onyx/information_model.cljc
+++ b/src/onyx/information_model.cljc
@@ -1480,7 +1480,8 @@ may be added by the user as the context is associated to throughout the task pip
                :onyx.core/compiled
                :onyx.core/drained-back-off 
                :onyx.core/messenger-buffer 
-               :onyx.core/state]
+               :onyx.core/state
+               :onyx.core/emitted-exhausted?]
    :env-config
    [:onyx/tenancy-id
     :zookeeper/server?

--- a/src/onyx/information_model.cljc
+++ b/src/onyx/information_model.cljc
@@ -600,7 +600,10 @@ may be added by the user as the context is associated to throughout the task pip
                                          :doc "The sequence of segments read by this peer"}
                        :onyx.core/results {:type :results
                                            :optional? true
-                                           :doc "A map of read segment to a vector of segments produced by applying the function of this task"}}}
+                                           :doc "A map of read segment to a vector of segments produced by applying the function of this task"}
+
+                       :onyx.core/emitted-exhausted? {:type :atom
+                                                      :doc "An atom with a boolean denoting whether this peer wrote out the exhausted log entry."}}}
    :state-event
    {:summary "A state event contains context about a state update, trigger call, or refinement update. It consists of a Clojure record, with some keys being nil, depending on the context of the call e.g. a trigger call may include context about the originating cause fo the trigger."
     :schema :onyx.schema.StateEvent

--- a/src/onyx/schema.cljc
+++ b/src/onyx/schema.cljc
@@ -711,6 +711,7 @@
        :boolean s/Bool
        :keyword s/Keyword
        :any s/Any
+       :atom clojure.lang.Atom
        :segment s/Any
        :peer-config PeerConfig
        :catalog-entry TaskMap


### PR DESCRIPTION
Fixes #493. As per the issue, I don't think it's a good idea to check the local replica if an exhausted input has been seen because in between the time that the log entry is written and until its been integrated back into the local replica, this entry will continue to be written. With a low batch timeout this could still cause some damage.

Instead, I've added a simple flag to only write to the outgoing channel exactly once.