### PR TITLE
Catch invalid cookie exception when starting Bookie

### DIFF
--- a/src/onyx/state/bookkeeper.clj
+++ b/src/onyx/state/bookkeeper.clj
@@ -17,9 +17,9 @@
   (FileUtils/deleteDirectory (File. ^String dir)))
 
 (defn- exception-chain
-  [exception]
+  [^Exception exception]
   (->> exception
-       (iterate (memfn getCause))
+       (iterate #(.getCause ^Exception %))
        (take-while identity)))
 
 (defn- invalid-cookie-exception?

--- a/src/onyx/state/bookkeeper.clj
+++ b/src/onyx/state/bookkeeper.clj
@@ -6,13 +6,26 @@
             [taoensso.timbre :refer [error info warn]])
   (:import java.io.File
            org.apache.bookkeeper.bookie.Bookie
+           [org.apache.bookkeeper.bookie BookieException$InvalidCookieException]
            org.apache.bookkeeper.conf.ServerConfiguration
            org.apache.bookkeeper.proto.BookieServer
            org.apache.commons.io.FileUtils
-           [org.apache.zookeeper KeeperException$NodeExistsException]))
+           [org.apache.zookeeper
+            KeeperException$NodeExistsException]))
 
 (defn cleanup-dir [dir]
   (FileUtils/deleteDirectory (File. ^String dir)))
+
+(defn- exception-chain
+  [exception]
+  (->> exception
+       (iterate (memfn getCause))
+       (take-while identity)))
+
+(defn- invalid-cookie-exception?
+  [^Exception exception]
+  (or (instance? BookieException$InvalidCookieException exception)
+      (instance? KeeperException$NodeExistsException exception)))
 
 (defrecord BookieComponent [env-config port log]
   component/Lifecycle
@@ -42,14 +55,15 @@
                         (.setDiskUsageWarnThreshold disk-usage-warn-threshold))
           server (try (BookieServer. server-conf)
                       (catch Exception e
-                        (if (instance? KeeperException$NodeExistsException (.getCause e))
-                          (let [cookie-path (format "%s/cookies/%s"
-                                                    ledgers-root-path
-                                                    (Bookie/getBookieAddress server-conf))]
-                            (info "Deleting existing Bookie cookie" cookie-path)
-                            (zk/delete (:conn log) cookie-path)
-                            (BookieServer. server-conf))
-                          (throw e))))]
+                        (let [chain (exception-chain e)]
+                          (if (some invalid-cookie-exception? chain)
+                            (let [cookie-path (format "%s/cookies/%s"
+                                                      ledgers-root-path
+                                                      (Bookie/getBookieAddress server-conf))]
+                              (info "Deleting existing Bookie cookie" cookie-path)
+                              (zk/delete (:conn log) cookie-path)
+                              (BookieServer. server-conf))
+                            (throw e)))))]
       (info "Starting BookKeeper server on port" port)
       (.start ^BookieServer server)
       (when (:onyx.bookkeeper/delete-server-data? env-config)


### PR DESCRIPTION
**Research** around invalid cookie exception when starting an embedded test system in https://github.com/onyx-platform/onyx-kafka/pull/26.

/cc @gardnervickers 

```
16-Jul-04 18:52:48 mbp.local INFO [onyx.static.logging-configuration] - Starting Logging Configuration
16-Jul-04 18:52:48 mbp.local INFO [onyx.log.zookeeper] - Starting ZooKeeper server
16-Jul-04 18:52:49 mbp.local INFO [onyx.state.bookkeeper] - Deleting existing Bookie cookie /onyx/testcluster/ledgers/cookies/192.168.1.51:3196
16-Jul-04 18:52:49 mbp.local FATAL [onyx.system] -
                                   clojure.main.main          main.java:   37
                                                 ...
                                   clojure.main/main           main.clj:  384
                                   clojure.main/main           main.clj:  421
                               clojure.main/null-opt           main.clj:  342
                             clojure.main/initialize           main.clj:  308
                               clojure.main/init-opt           main.clj:  277
                            clojure.main/load-script           main.clj:  275
                                                 ...
                                         user/eval91          REPL Input
                                      user/eval91/fn          REPL Input
                                   user/eval91/fn/fn          REPL Input      (repeats 2 times)
                                  clojure.core/apply           core.clj:  646
                                                 ...
                              clojure.test/run-tests           test.clj:  767 (repeats 2 times)
                                  clojure.core/apply           core.clj:  648
                                                 ...
                                 clojure.core/map/fn           core.clj: 2646
                                clojure.test/test-ns           test.clj:  757
                          clojure.test/test-all-vars           test.clj:  736
                              clojure.test/test-vars           test.clj:  730
                        clojure.test/default-fixture           test.clj:  686
                           clojure.test/test-vars/fn           test.clj:  734
                        clojure.test/default-fixture           test.clj:  686
                        clojure.test/test-vars/fn/fn           test.clj:  734
                               clojure.test/test-var           test.clj:  716
                            clojure.test/test-var/fn           test.clj:  716
                          onyx.plugin.output-test/fn    output_test.clj:   57
                  onyx.test-helper.OnyxTestEnv/start    test_helper.clj:  135
                      onyx.test-helper/try-start-env    test_helper.clj:   89
                                  onyx.api/start-env            api.clj:  346
                                  onyx.api/start-env            api.clj:  349
                onyx.system.OnyxDevelopmentEnv/start         system.clj:   88
                       onyx.system/rethrow-component         system.clj:   80
                   onyx.system.OnyxDevelopmentEnv/fn         system.clj:   89
             com.stuartsierra.component/start-system      component.clj:  162
                                                 ...
            com.stuartsierra.component/update-system      component.clj:  128
            com.stuartsierra.component/update-system      component.clj:  134
                                 clojure.core/reduce           core.clj: 6544
                                                 ...
         com.stuartsierra.component/update-system/fn      component.clj:  138
               com.stuartsierra.component/try-action      component.clj:  116
                                  clojure.core/apply           core.clj:  648
                                                 ...
            com.stuartsierra.component/eval7958/fn/G      component.clj:    4 (repeats 2 times)
           onyx.state.bookkeeper.BookieServers/start     bookkeeper.clj:  129
                                   clojure.core/mapv           core.clj: 6618
                                 clojure.core/reduce           core.clj: 6544
                                                 ...
                                clojure.core/mapv/fn           core.clj: 6627
              onyx.state.bookkeeper.BookieServers/fn     bookkeeper.clj:  130
           onyx.state.bookkeeper.BookieMonitor/start     bookkeeper.clj:   96
         onyx.state.bookkeeper.BookieComponent/start     bookkeeper.clj:   56
            onyx.state.bookkeeper.BookieComponent/fn     bookkeeper.clj:   64
     org.apache.bookkeeper.proto.BookieServer.<init>  BookieServer.java:   88
     org.apache.bookkeeper.proto.BookieServer.<init>  BookieServer.java:   96
  org.apache.bookkeeper.proto.BookieServer.newBookie  BookieServer.java:  110
          org.apache.bookkeeper.bookie.Bookie.<init>        Bookie.java:  494
org.apache.bookkeeper.bookie.Bookie.checkEnvironment        Bookie.java:  378
org.apache.bookkeeper.bookie.BookieException$InvalidCookieException:
    code: 0
                                         clojure.lang.ExceptionInfo: Error in component :bookkeeper in system onyx.system.OnyxDevelopmentEnv calling #'com.stuartsierra.component/start
     component: #<Bookie Servers>
      function: #'com.stuartsierra.component/start
        reason: :com.stuartsierra.component/component-function-threw-exception
        system: #onyx.system.OnyxDevelopmentEnv{:monitoring #<NoOp Monitoring Agent>, :logging-config #<Logging Configuration>, :bookkeeper #<Bookie Servers>, :log #<ZooKeeper Component>}
    system-key: :bookkeeper
```