### PR TITLE
Bookie in-memory server cleanup on shutdown

### DIFF
--- a/src/onyx/state/bookkeeper.clj
+++ b/src/onyx/state/bookkeeper.clj
@@ -73,7 +73,7 @@
           (throw (ex-info "The Bookie server failed to start because a cookie or
                            ledger already exists for this host. Set
                            :onyx.bookkeeper/delete-server-data? true to format
-                           the Bookie environment."))
+                           the Bookie environment on component shutdown."))
           (throw e)))))
   (stop [{:keys [server server-conf] :as component}]
     (info "Stopping BookKeeper server:")

--- a/src/onyx/state/bookkeeper.clj
+++ b/src/onyx/state/bookkeeper.clj
@@ -56,6 +56,10 @@
                           (.setDiskUsageThreshold disk-usage-threshold)
                           (.setDiskUsageWarnThreshold disk-usage-warn-threshold))
             server (BookieServer. server-conf)]
+        (when (:onyx.bookkeeper/delete-server-data? env-config)
+          (.addShutdownHook (Runtime/getRuntime)
+                            (Thread. (fn []
+                                       (format-bk-server server-conf (:conn log))))))
         (info "Starting BookKeeper server on port" port)
         (info "Creating Bookie dirs" journal-dir ";" ledger-dir)
         (.start ^BookieServer server)
@@ -71,7 +75,6 @@
                            :onyx.bookkeeper/delete-server-data? true to format
                            the Bookie environment on startup."))
           (throw e)))))
-
   (stop [{:keys [server server-conf] :as component}]
     (info "Stopping BookKeeper server:")
     (.shutdown ^BookieServer server)

--- a/src/onyx/state/bookkeeper.clj
+++ b/src/onyx/state/bookkeeper.clj
@@ -4,71 +4,80 @@
             [onyx.log.zookeeper :as ozk]
             [onyx.static.default-vals :refer [arg-or-default]]
             [taoensso.timbre :refer [error info warn]])
-  (:import java.io.File
-           org.apache.bookkeeper.bookie.Bookie
-           org.apache.bookkeeper.conf.ServerConfiguration
-           org.apache.bookkeeper.proto.BookieServer
-           org.apache.commons.io.FileUtils
+  (:import [java.io File]
+           [org.apache.bookkeeper.bookie Bookie BookieException$InvalidCookieException]
+           [org.apache.bookkeeper.conf ServerConfiguration]
+           [org.apache.bookkeeper.proto BookieServer]
+           [org.apache.commons.io FileUtils]
            [org.apache.zookeeper KeeperException$NodeExistsException]))
 
 (defn cleanup-dir [dir]
   (FileUtils/deleteDirectory (File. ^String dir)))
 
+(defn format-bk-server
+  "Delete journal/ledger directories and removes corresponding cookie in Zookeeper"
+  [server-conf zk-conn]
+  (let [journal-dir (str (.getJournalDirName server-conf))
+        ledger-dir (str (first (.getLedgerDirNames server-conf)))
+        cookie-path (format "%s/cookies/%s"
+                            (.getZkLedgersRootPath server-conf)
+                            (Bookie/getBookieAddress server-conf))]
+    (info "Deleting Bookie cookie" cookie-path)
+    (zk/delete zk-conn cookie-path)
+    (info "Deleting Bookie dirs" journal-dir ";" ledger-dir)
+    (cleanup-dir journal-dir)
+    (cleanup-dir ledger-dir)))
+
 (defrecord BookieComponent [env-config port log]
   component/Lifecycle
   (start [component]
-    (let [onyx-id (:onyx/tenancy-id env-config)
-          ledgers-root-path (ozk/ledgers-path onyx-id)
-          ledgers-available-path (ozk/ledgers-available-path onyx-id)
-          _ (zk/create (:conn log) ledgers-root-path :persistent? true)
-          _ (zk/create (:conn log) ledgers-available-path :persistent? true)
-          base-journal-dir (arg-or-default :onyx.bookkeeper/base-journal-dir env-config)
-          base-ledger-dir (arg-or-default :onyx.bookkeeper/base-ledger-dir env-config)
-          ;; allow loopback? only if running a local quorum
-          allow-loopback? (boolean (arg-or-default :onyx.bookkeeper/local-quorum? env-config))
-          disk-usage-threshold (arg-or-default :onyx.bookkeeper/disk-usage-threshold env-config)
-          disk-usage-warn-threshold (arg-or-default :onyx.bookkeeper/disk-usage-warn-threshold env-config)
-          server-id (str onyx-id "_" port)
-          journal-dir (str base-journal-dir "/" server-id)
-          ledger-dir (str base-ledger-dir "/" server-id)
-          server-conf (doto (ServerConfiguration.)
-                        (.setZkServers (:zookeeper/address env-config))
-                        (.setZkLedgersRootPath ledgers-root-path)
-                        (.setBookiePort port)
-                        (.setJournalDirName journal-dir)
-                        (.setLedgerDirNames (into-array String [ledger-dir]))
-                        (.setAllowLoopback allow-loopback?)
-                        (.setDiskUsageThreshold disk-usage-threshold)
-                        (.setDiskUsageWarnThreshold disk-usage-warn-threshold))
-          server (try (BookieServer. server-conf)
-                      (catch Exception e
-                        (if (instance? KeeperException$NodeExistsException (.getCause e))
-                          (let [cookie-path (format "%s/cookies/%s"
-                                                    ledgers-root-path
-                                                    (Bookie/getBookieAddress server-conf))]
-                            (info "Deleting existing Bookie cookie" cookie-path)
-                            (zk/delete (:conn log) cookie-path)
-                            (BookieServer. server-conf))
-                          (throw e))))]
-      (info "Starting BookKeeper server on port" port)
-      (.start ^BookieServer server)
-      (when (:onyx.bookkeeper/delete-server-data? env-config)
-        (.addShutdownHook (Runtime/getRuntime)
-                          (Thread. (fn []
-                                     (cleanup-dir base-ledger-dir)
-                                     (cleanup-dir base-journal-dir)))))
-      (assoc component
-             :server server
-             :port port
-             :journal-dir journal-dir
-             :ledger-dir ledger-dir)))
+    (try
+      (let [onyx-id (:onyx/tenancy-id env-config)
+            ledgers-root-path (ozk/ledgers-path onyx-id)
+            ledgers-available-path (ozk/ledgers-available-path onyx-id)
+            _ (zk/create (:conn log) ledgers-root-path :persistent? true)
+            _ (zk/create (:conn log) ledgers-available-path :persistent? true)
+            base-journal-dir (arg-or-default :onyx.bookkeeper/base-journal-dir env-config)
+            base-ledger-dir (arg-or-default :onyx.bookkeeper/base-ledger-dir env-config)
+            ;; allow loopback? only if running a local quorum
+            allow-loopback? (boolean (arg-or-default :onyx.bookkeeper/local-quorum? env-config))
+            disk-usage-threshold (arg-or-default :onyx.bookkeeper/disk-usage-threshold env-config)
+            disk-usage-warn-threshold (arg-or-default :onyx.bookkeeper/disk-usage-warn-threshold env-config)
+            server-id (str onyx-id "_" port)
+            journal-dir (str base-journal-dir "/" server-id)
+            ledger-dir (str base-ledger-dir "/" server-id)
+            server-conf (doto (ServerConfiguration.)
+                          (.setZkServers (:zookeeper/address env-config))
+                          (.setZkLedgersRootPath ledgers-root-path)
+                          (.setBookiePort port)
+                          (.setJournalDirName journal-dir)
+                          (.setLedgerDirNames (into-array String [ledger-dir]))
+                          (.setAllowLoopback allow-loopback?)
+                          (.setDiskUsageThreshold disk-usage-threshold)
+                          (.setDiskUsageWarnThreshold disk-usage-warn-threshold))
+            server (BookieServer. server-conf)]
+        (info "Starting BookKeeper server on port" port)
+        (info "Creating Bookie dirs" journal-dir ";" ledger-dir)
+        (.start ^BookieServer server)
+        (assoc component
+               :server server
+               :server-conf server-conf
+               :port port))
+      (catch Exception e
+        (if (or (instance? BookieException$InvalidCookieException (.getCause e))
+                (instance? KeeperException$NodeExistsException (.getCause e)))
+          (throw (ex-info "The Bookie server failed to start because a cookie or
+                           ledger already exists for this host. Set
+                           :onyx.bookkeeper/delete-server-data? true to format
+                           the Bookie environment on startup."))
+          (throw e)))))
 
-  (stop [{:keys [server] :as component}]
-    (info "Stopping BookKeeper server")
+  (stop [{:keys [server server-conf] :as component}]
+    (info "Stopping BookKeeper server:")
     (.shutdown ^BookieServer server)
+    (info "Stopped BookKeeper server with exit code:" (.getExitCode server))
     (when (:onyx.bookkeeper/delete-server-data? env-config)
-      (cleanup-dir (:journal-dir component))
-      (cleanup-dir (:ledger-dir component)))
+      (format-bk-server server-conf (:conn log)))
     (assoc component :server nil :port nil :journal-dir nil :ledger-dir nil)))
 
 (defn started? [bookie]

--- a/src/onyx/state/bookkeeper.clj
+++ b/src/onyx/state/bookkeeper.clj
@@ -16,7 +16,7 @@
 
 (defn format-bk-server
   "Delete journal/ledger directories and removes corresponding cookie in Zookeeper"
-  [server-conf zk-conn]
+  [^ServerConfiguration server-conf zk-conn]
   (let [journal-dir (str (.getJournalDirName server-conf))
         ledger-dir (str (first (.getLedgerDirNames server-conf)))
         cookie-path (format "%s/cookies/%s"
@@ -73,12 +73,12 @@
           (throw (ex-info "The Bookie server failed to start because a cookie or
                            ledger already exists for this host. Set
                            :onyx.bookkeeper/delete-server-data? true to format
-                           the Bookie environment on startup."))
+                           the Bookie environment."))
           (throw e)))))
   (stop [{:keys [server server-conf] :as component}]
     (info "Stopping BookKeeper server:")
     (.shutdown ^BookieServer server)
-    (info "Stopped BookKeeper server with exit code:" (.getExitCode server))
+    (info "Stopped BookKeeper server with exit code:" (.getExitCode ^BookieServer server))
     (when (:onyx.bookkeeper/delete-server-data? env-config)
       (format-bk-server server-conf (:conn log)))
     (assoc component :server nil :port nil :journal-dir nil :ledger-dir nil)))


### PR DESCRIPTION
Previously we were catching an exception and deleting a node in Zookeeper, what we really want to do is provide the same functionality as the Bookkeeper Admin tool, where you can [format](https://bookkeeper.apache.org/docs/r4.3.0/apidocs/org/apache/bookkeeper/client/BookKeeperAdmin.html#format(org.apache.bookkeeper.conf.ClientConfiguration, boolean, boolean)) the local filesystem and ZooKeeper filesystem. 

We trigger this when `:onyx.bookkeeper/delete-server-data? true`, if we detect there's a mismatched cookie/directory, then we should inform the user that `:onyx.bookkeeper/delete-server-data? true` can be used. There are other ways to recover BookKeeper data and we don't want to destroy the Cookie without the user explicitly instructing us to.

This is in relation to and replaces #610