### PR TITLE
Normalize lifecycle exceptions for deserialize-ability

### DIFF
--- a/src/onyx/compression/nippy.clj
+++ b/src/onyx/compression/nippy.clj
@@ -9,9 +9,29 @@
                                                   :str (.getMessage x)
                                                   :cause (.getCause x)})))
 
+(defn exception-info-reader [tag value]
+  (let [maybe-record? (pos? (.indexOf (name tag) "."))]
+    (if-not maybe-record?
+      {:tag (keyword tag)
+       :value value
+       :deserialize-attempted? false}
+      (try
+        (let [rec-class (Class/forName (name tag))
+              create-method (.getMethod rec-class
+                                        "create"
+                                        (into-array Class [clojure.lang.IPersistentMap]))]
+          (.invoke create-method rec-class (into-array Object [value])))
+        (catch Throwable ex
+          {:tag (keyword tag)
+           :value value
+           :deserialize-attempted? true
+           :deserialize-exception-type (keyword (type ex))})))))
+
 (nippy/extend-thaw :onyx/exception-info
                    [data-input]
-                   (let [{:keys [ex str cause]} (read-string (.readUTF data-input))]
+                   (let [{:keys [ex str cause]}
+                         (clojure.edn/read-string {:default exception-info-reader}
+                                                  (.readUTF data-input))]
                      (clojure.lang.ExceptionInfo. str ex cause)))
 
 (def messaging-compress-opts {})

--- a/src/onyx/compression/nippy.clj
+++ b/src/onyx/compression/nippy.clj
@@ -1,6 +1,7 @@
 (ns onyx.compression.nippy
   (:require [taoensso.nippy :as nippy]
-            [schema.utils :as su])
+            [schema.utils :as su]
+            [clojure.edn])
   (:import [schema.utils ValidationError NamedError]))
 
 (nippy/extend-freeze clojure.lang.ExceptionInfo :onyx/exception-info

--- a/src/onyx/compression/nippy.clj
+++ b/src/onyx/compression/nippy.clj
@@ -25,7 +25,7 @@
           {:tag (keyword tag)
            :value value
            :deserialize-attempted? true
-           :deserialize-exception-type (keyword (type ex))})))))
+           :deserialize-exception-type (type ex)})))))
 
 (nippy/extend-thaw :onyx/exception-info
                    [data-input]

--- a/src/onyx/peer/task_lifecycle.clj
+++ b/src/onyx/peer/task_lifecycle.clj
@@ -331,7 +331,7 @@
 
 (defn deserializable-exception [^Throwable throwable]
   (let [{:keys [data trace]} (Throwable->map throwable)
-        data (assoc data :original-exception-name (.getName (.getClass throwable)))]   
+        data (assoc data :original-exception (keyword (.getName (.getClass throwable))))]   
     (doto ^Throwable (ex-info (.getMessage throwable) data)
       (.setStackTrace (into-array StackTraceElement trace)))))
 

--- a/src/onyx/peer/task_lifecycle.clj
+++ b/src/onyx/peer/task_lifecycle.clj
@@ -329,6 +329,12 @@
               (swap! (:onyx.core/state event) update :timeout-pool rsc/expire-bucket)
               (recur))))))))
 
+(defn deserializable-exception [^Throwable throwable]
+  (let [{:keys [data trace]} (Throwable->map throwable)
+        data (assoc data :original-exception-name (.getName (.getClass throwable)))]   
+    (doto ^Throwable (ex-info (.getMessage throwable) data)
+      (.setStackTrace (into-array StackTraceElement trace)))))
+
 (defn handle-exception [task-info log e group-ch outbox-ch id job-id]
   (let [data (ex-data e)
         inner (.getCause ^Throwable e)]
@@ -337,7 +343,7 @@
           (>!! group-ch [:restart-vpeer id]))
       (do (warn (logger/merge-error-keys e task-info "Handling uncaught exception thrown inside task lifecycle - killing this job."))
           (let [entry (entry/create-log-entry :kill-job {:job job-id})]
-            (extensions/write-chunk log :exception e job-id)
+            (extensions/write-chunk log :exception (deserializable-exception e) job-id)
             (>!! outbox-ch entry))))))
 
 (s/defn assign-windows :- Event

--- a/test/onyx/peer/serialized_exception_test.clj
+++ b/test/onyx/peer/serialized_exception_test.clj
@@ -76,4 +76,4 @@
         (onyx.api/await-job-completion peer-config job-id)
         (let [e (extensions/read-chunk (:log (:env test-env)) :exception job-id)]
           (is (= "Exception message" (.getMessage e)))
-          (is (= {:exception-data 42} (ex-data e))))))))
+          (is (= 42 (:exception-data (ex-data e)))))))))


### PR DESCRIPTION
Aims to resolve onyx-platform/onyx#627

From @lbradstreet:
> Sometimes exceptions written by kill job will contain types that are not deserializable by a JVM that did not produce them. We should either write a string version of the exception, or provide a better error in feedback-exception! / onyx-dashboard when the exception can't be deserialised

My (newbie) assumptions:
* The relevant exceptions are written to the log when some part of the task lifecycle throws.
* We could see the deserialization issue, for example, if a peer (JVM A), throws an exception that is read off the log by a consuming client like onyx-dashboard (JVM B), where the classpath does not include the exception type.

This PR's approach wraps the original throwable in an ex-info that preserves the exception message and stack trace. The ex-data key `:original-exception` carries the keyword form of the original exception class name.

Compared to the string-version approach, I think this has the advantage of maintaining a Throwable instance as the log entry's :exception value. And it has less surface area compared to handling the issue case downstream in the dashboard or tests. Tradeoff: consuming code can't catch specific exception types; `:original-exception` would need to be leveraged instead.

Thoughts? Hope this helps!
