### PR TITLE
Balanced scheduler allocations

### DIFF
--- a/src/onyx/peer/task_lifecycle.clj
+++ b/src/onyx/peer/task_lifecycle.clj
@@ -284,28 +284,33 @@
        (loop []
          (when-let [[v ch] (alts!! [task-kill-ch completion-ch seal-ch release-ch retry-ch])]
            (when v
-             (cond (= ch release-ch)
-                   (->> (p-ext/ack-segment pipeline event v)
-                        (lc/invoke-after-ack event compiled v))
+             (try 
+              (cond (= ch release-ch)
+                    (->> (p-ext/ack-segment pipeline event v)
+                         (lc/invoke-after-ack event compiled v))
 
-                   (= ch completion-ch)
-                   (let [{:keys [id peer-id]} v
-                         site (peer-site peer-replica-view peer-id)]
-                     (when site 
-                       (emit-latency :peer-complete-segment
-                                     monitoring
-                                     #(extensions/internal-complete-segment messenger id site))))
+                    (= ch completion-ch)
+                    (let [{:keys [id peer-id]} v
+                          site (peer-site peer-replica-view peer-id)]
+                      (when site 
+                        (emit-latency :peer-complete-segment
+                                      monitoring
+                                      #(extensions/internal-complete-segment messenger id site))))
 
-                   (= ch retry-ch)
-                   (->> (p-ext/retry-segment pipeline event v)
-                        (lc/invoke-after-retry event compiled v))
+                    (= ch retry-ch)
+                    (->> (p-ext/retry-segment pipeline event v)
+                         (lc/invoke-after-retry event compiled v))
 
-                   (= ch seal-ch)
-                   (do
+                    (= ch seal-ch)
+                    (do
                      (p-ext/seal-resource pipeline event)
                      (let [entry (entry/create-log-entry :seal-output {:job (:onyx.core/job-id event)
                                                                        :task (:onyx.core/task-id event)})]
                        (>!! outbox-ch entry))))
+              (catch IllegalArgumentException iae
+                (info "Message arrived for a peer when it was allocated for alternative task.
+                       This is generally safe to ignore, but may result due to high peer allocation churn.
+                       Error:" (.getMessage iae))))
              (recur)))))
      (catch Throwable e
        (fatal (logger/merge-error-keys e (:onyx.core/task-information event) "Internal error. Failed to read core.async channels"))))))

--- a/src/onyx/scheduling/balanced_job_scheduler.clj
+++ b/src/onyx/scheduling/balanced_job_scheduler.clj
@@ -26,28 +26,44 @@
 
 ;; filter out saturated, then sort by is-covered? (yes before no),
 ;; then by number of allocated peers
-
 (defn select-job-requiring-peer
   "Selects the next job deserving a peer.
   Tries to cover job requiring the least peers to cover first,
   then tries to balance by peer count"
-  [replica jobs]
+  [replica jobs n-remaining]
   (->> jobs
-       (sort-by (fn [[job-id peer-count :as job]]
-                  (let [covered (max 0 (- (cjs/job-lower-bound replica job-id) peer-count))]
-                    (vector covered
-                            peer-count
-                            (index-of (:jobs replica) job-id)))))
+       ;; remove all fully allocated jobs
        (remove (fn [[job-id peer-count]]
                  (>= peer-count (cjs/job-upper-bound replica job-id))))
+       ;; only allocate to jobs that are potentially coverable or already covered
+       (filter (fn [[job-id peer-count]]
+                 (>= (+ peer-count n-remaining) 
+                     (cjs/job-lower-bound replica job-id))))
+       (sort-by (fn [[job-id peer-count :as job]]
+                  (let [covered? (>= peer-count (cjs/job-lower-bound replica job-id))
+                        remaining-required (max 0 (- (cjs/job-lower-bound replica job-id) peer-count))]
+                    (vector ;; try to assign to uncovered over covered
+                            covered?
+                            ;; then assign to the job with the least remaining required
+                            remaining-required
+                            ;; uncovered, lowest peer count
+                            peer-count
+                            (index-of (:jobs replica) job-id)))))
        (ffirst)))
 
+
+;; Take all the claimable peers
+;; 1. Allocate as many to the first uncovered job that you can fully cover with all those peers
+;;    up to however many it requires
+;; 2. If there are no jobs that can be allocated, allocate one peer to the job with 
+;;    the minimum number of peers that is not fully covered
+;; TODO: this should be replaced by btrplace constraints
 (defmethod cjs/claim-spare-peers :onyx.job-scheduler/balanced
   [replica jobs n]
   (loop [jobs* jobs n* n]
     (if (zero? n*)
       jobs*
-      (let [job (select-job-requiring-peer replica jobs*)]
+      (let [job (select-job-requiring-peer replica jobs* n*)]
         (if job
           (recur (update jobs* job inc)
                  (dec n*))

--- a/test/onyx/flow_conditions/flow_conditions_gen_test.clj
+++ b/test/onyx/flow_conditions/flow_conditions_gen_test.clj
@@ -106,7 +106,7 @@
 (deftest conj-downstream-tasks-together
   (checking
    "It joins the :flow/to tasks together and limits selection"
-   (times 15)
+   (times 5)
    [flow-conditions
     (gen/not-empty
      (gen/vector (->> :a
@@ -126,7 +126,7 @@
 (deftest no-false-predicate-picks
   (checking
    "It doesn't pick any downstream tasks with false predicates"
-   (times 15)
+   (times 5)
    [true-fcs
     (gen/vector (->> :a
                      (flow-condition-gen)
@@ -149,7 +149,7 @@
 (deftest short-circuit
   (checking
    "It stops searching when it finds a short circuit true pred"
-   (times 15)
+   (times 5)
    [false-1
     (gen/vector (->> :a
                      (flow-condition-gen)
@@ -185,7 +185,7 @@
 (deftest retry-action
   (checking
    "Using a retry action with a true predicate flows to nil"
-   (times 15)
+   (times 5)
    [retry-false
     (gen/vector (->> :a
                      (flow-condition-gen)
@@ -232,7 +232,7 @@
 (deftest key-exclusion
   (checking
    "Matched predicates excluded keys are conj'ed together"
-   (times 15)
+   (times 5)
    [mixed
     (gen/vector
      (gen/one-of [(->> :a
@@ -256,7 +256,7 @@
 (deftest matching-all
   (checking
    "A :flow/to of :all that passes its predicate matches everything"
-   (times 15)
+   (times 5)
    [false-all
     (gen/vector (->> :a
                      (flow-condition-gen)
@@ -290,7 +290,7 @@
 (deftest matching-none
   (checking
    "A :flow/to of :none that passes its pred matches nothing"
-   (times 15)
+   (times 5)
    [false-none
     (gen/vector (->> :a
                      (flow-condition-gen)
@@ -324,7 +324,7 @@
 (deftest post-transformation
   (checking
    "A :flow/post-transform is returned for exception predicates that define it"
-   (times 15)
+   (times 5)
    [false-xform
     (gen/vector (->> :a
                      (flow-condition-gen)
@@ -358,7 +358,7 @@
 (deftest post-transformation-no-invocation
   (checking
    "Post-transformations are not invoked when they are not matched"
-   (times 15)
+   (times 5)
    [fcs
     (gen/not-empty
      (gen/vector (->> :a
@@ -379,7 +379,7 @@
 (deftest post-transformation-invocation
   (checking
    "Post-transformations are invoked when they are matched"
-   (times 15)
+   (times 5)
    [fcs
     (gen/not-empty
      (gen/vector (->> :a
@@ -402,7 +402,7 @@
 (deftest post-transformation-exclusions
   (checking
    "Key exclusions are applied during post transformation"
-   (times 15)
+   (times 5)
    [fcs
     (gen/vector (->> :a
                      (flow-condition-gen)
@@ -422,7 +422,7 @@
 (deftest none-placed-after-all
   (checking
     ":flow/to :none placed after :flow/to :all"
-    (times 15)
+    (times 5)
     [fcs-all (gen/not-empty
                (gen/vector (->> :a
                                 (flow-condition-gen)
@@ -437,7 +437,7 @@
 (deftest none-placed-before-other
   (checking
     ":flow/to :none placed first if there is no :flow/to :all"
-    (times 15)
+    (times 5)
     [fcs-other (gen/not-empty
                (gen/vector (->> :a
                                 (flow-condition-gen)
@@ -453,7 +453,7 @@
 (deftest short-circuit-placed-before-other
   (checking
     ":flow/short-circuit? true should be placed before other conditions"
-    (times 15)
+    (times 5)
     [fcs-other (gen/not-empty
                  (gen/vector (->> :a
                                   (flow-condition-gen))))

--- a/test/onyx/generative/apply_fn_gen_test.clj
+++ b/test/onyx/generative/apply_fn_gen_test.clj
@@ -19,10 +19,10 @@
 (defn gen-segment []
   (gen/hash-map :message (segment-map)))
 
-(deftest singe-segment-return
+(deftest single-segment-return
   (checking
    "A single returned segment attaches to its root"
-   (times 15)
+   (times 10)
    [input (gen-segment)
     output (segment-map)]
    (let [f (fn [segment] output)
@@ -35,7 +35,7 @@
 (deftest multi-segment-return
   (checking
    "Multiple segments can be returned, attached to their root"
-   (times 15)
+   (times 10)
    [input (gen-segment)
     output (gen/vector (segment-map))]
    (let [f (fn [segment] output)
@@ -48,7 +48,7 @@
 (deftest multi-batch-size-single-rets
   (checking
    "It generalizes with a bigger batch size for single returns"
-   (times 15)
+   (times 10)
    ;; Uses a unique mapping of keys to values to look up an
    ;; input for an output with no collisions.
    [input (gen/vector (gen/hash-map
@@ -70,7 +70,7 @@
 (deftest parameterized-functions
   (checking
    "Functions can be parameterized via the event map"
-   (times 15)
+   (times 10)
    [input (gen/vector (gen-segment))
     params (gen/vector (gen/resize 10 gen/any))]
    (let [f (fn [& args] {:result (or (butlast args) [])})
@@ -82,7 +82,7 @@
 (deftest throws-exception
   (checking
    "Functions that throw exceptions pass the exception object back"
-   (times 15)
+   (times 10)
    [input (gen/vector (gen-segment))]
    (let [f (fn [segment] (throw (ex-info "exception" {:val 42})))
          event {:onyx.core/batch input}
@@ -96,7 +96,7 @@
 (deftest batch-functions
   (checking
    "Batch functions call the function, but must return as many inputs as outputs"
-   (times 15)
+   (times 10)
    [input (gen/not-empty (gen/vector (gen-segment)))
     output (gen/resize 10 gen/any)]
    (let [called? (atom false)
@@ -111,7 +111,7 @@
 (deftest supplied-params
   (checking
    "Supplied parameters concat in the right order"
-   (times 15)
+   (times 10)
    [fn-params (gen/vector (gen/resize 10 gen/any))
     catalog-params (gen/hash-map gen/keyword (gen/resize 10 gen/any))]
    (let [task-name :a

--- a/test/onyx/scheduler/balanced_generative_test.clj
+++ b/test/onyx/scheduler/balanced_generative_test.clj
@@ -8,13 +8,14 @@
             [onyx.test-helper :refer [job-allocation-counts]]
             [clojure.set :refer [intersection]]
             [clojure.test.check :as tc]
+            [clojure.test.check.clojure-test :refer [defspec]]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
             [clojure.test :refer :all]
             [onyx.log.replica :as replica]
             [onyx.log.commands.common :as common]
             [com.gfredericks.test.chuck :refer [times]]
-            [com.gfredericks.test.chuck.clojure-test :refer [checking]]
+            [com.gfredericks.test.chuck.clojure-test :refer [checking for-all]]
             [taoensso.timbre :refer [info]]))
 
 (def onyx-id (java.util.UUID/randomUUID))
@@ -53,39 +54,48 @@
               :onyx/batch-size 20}]
    :task-scheduler :onyx.task-scheduler/balanced})
 
-(deftest combined-jobs
-  (let [n-jobs 4
-        n-peers 21
-        job-ids (repeatedly n-jobs #(java.util.UUID/randomUUID))
-        jobs-rets (map (fn [job-id]
-                         (api/create-submit-job-entry job-id
-                                                      peer-config
-                                                      job
-                                                      (planning/discover-tasks (:catalog job) (:workflow job))))
-                       job-ids)]
-    (checking
-     "Checking peers are allocated to job 1 even though job 2 is submitted and can't start."
-     (times 50)
-     [{:keys [replica log peer-choices]}
-      (log-gen/apply-entries-gen
-       (gen/return
-        {:replica base-replica 
-         :message-id 0
-         :entries (assoc (log-gen/generate-join-queues (log-gen/generate-group-and-peer-ids 1 n-peers))
-                         :jobs {:queue jobs-rets})
-         :log []
-         :peer-choices []}))]
-     (is (= 3 (count (:jobs replica))))
-     (println "Jobs" (:jobs replica))
-     (println "Allocatios" (:allocations replica))
-     #_(let [[t1 t2 t3] (:tasks (:args job-1-rets))
-           [t4 t5 t6] (:tasks (:args job-2-rets))]
-       (is (= 3 (count (get (get (:allocations replica) job-1-id) t1))))
-       (is (= 4 (count (get (get (:allocations replica) job-1-id) t2))))
-       (is (= 3 (count (get (get (:allocations replica) job-1-id) t3))))
-
-       (is (= 0 (count (get (get (:allocations replica) job-2-id) t4))))
-       (is (= 0 (count (get (get (:allocations replica) job-2-id) t5))))
-       (is (= 0 (count (get (get (:allocations replica) job-2-id) t6)))))
-     
-     )))
+(defspec allocate-as-many-jobs-as-possible {:num-tests (times 10)}
+  (let [;; TODO, make these parameters part of the property testing
+        min-peers-per-job 6]
+    (for-all [n-jobs (gen/such-that #(< % 10) gen/s-pos-int 1000)
+              n-jobs-to-allocate (gen/elements (range 0 (inc n-jobs))) 
+              ;; add excess peers, but not enough to allocate an extra job
+              n-excess (gen/elements (range 1 6))
+              n-peers (gen/return (+ n-excess (* min-peers-per-job n-jobs-to-allocate)))
+              job-ids (gen/vector gen/uuid n-jobs)
+              jobs-rets (gen/return (mapv (fn [job-id]
+                                            (api/create-submit-job-entry job-id
+                                                                         peer-config
+                                                                         job
+                                                                         (planning/discover-tasks (:catalog job) 
+                                                                                                  (:workflow job))))
+                                          job-ids))
+              {:keys [replica log peer-choices]} 
+              (log-gen/apply-entries-gen
+               (gen/return
+                {:replica base-replica 
+                 :message-id 0
+                 :entries (assoc (log-gen/generate-join-queues (log-gen/generate-group-and-peer-ids 1 n-peers))
+                                 :jobs {:queue jobs-rets})
+                 :log []
+                 :peer-choices []}))]
+             (is (= n-jobs-to-allocate 
+                    (count (:allocations replica))) "as many jobs are allocated as possible")
+             (let [allocation-counts (map (fn [job-id]
+                                            (reduce + (map (comp count val) 
+                                                           (get-in replica [:allocations job-id]))))
+                                          job-ids)]
+               (let [sorted-cnts (-> allocation-counts
+                                     set
+                                     (disj 0)
+                                     vec
+                                     sort)]
+                 (is (or (< (count sorted-cnts) 2)
+                         ;; at max two possible counts can exist because everything should be balanced
+                         ;; e.g. 7 on one job, and 8 on two jobs
+                         (and (= (count sorted-cnts) 2)
+                              (= (inc (first sorted-cnts)) (second sorted-cnts))))))
+               (is (every? (fn [cnt]
+                             (or (zero? cnt) (>= cnt 6)))
+                           allocation-counts)
+                   ["no partially allocated jobs" (:allocations replica)])))))

--- a/test/onyx/scheduler/balanced_generative_test.clj
+++ b/test/onyx/scheduler/balanced_generative_test.clj
@@ -1,0 +1,91 @@
+(ns onyx.scheduler.balanced-generative-test
+  (:require [onyx.messaging.dummy-messenger :refer [dummy-messenger]]
+            [onyx.log.generators :as log-gen]
+            [onyx.extensions :as extensions]
+            [onyx.system]
+            [onyx.api :as api]
+            [onyx.static.planning :as planning]
+            [onyx.test-helper :refer [job-allocation-counts]]
+            [clojure.set :refer [intersection]]
+            [clojure.test.check :as tc]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
+            [clojure.test :refer :all]
+            [onyx.log.replica :as replica]
+            [onyx.log.commands.common :as common]
+            [com.gfredericks.test.chuck :refer [times]]
+            [com.gfredericks.test.chuck.clojure-test :refer [checking]]
+            [taoensso.timbre :refer [info]]))
+
+(def onyx-id (java.util.UUID/randomUUID))
+
+(def peer-config
+  {:onyx/tenancy-id onyx-id
+   :onyx.messaging/impl :dummy-messenger
+   :onyx.peer/try-join-once? true})
+
+(def base-replica 
+  (merge replica/base-replica
+         {:job-scheduler :onyx.job-scheduler/balanced
+          :messaging {:onyx.messaging/impl :dummy-messenger}}))
+
+(def messenger (dummy-messenger {}))
+
+(def job
+  {:workflow [[:a :b] [:b :c]]
+   :catalog [{:onyx/name :a
+              :onyx/plugin :onyx.test-helper/dummy-input
+              :onyx/type :input
+              :onyx/medium :dummy
+              :onyx/batch-size 20}
+
+             {:onyx/name :b
+              :onyx/fn :mock/fn
+              :onyx/type :function
+              :onyx/min-peers 4
+              :onyx/max-peers 4
+              :onyx/batch-size 20}
+
+             {:onyx/name :c
+              :onyx/plugin :onyx.test-helper/dummy-output
+              :onyx/type :output
+              :onyx/medium :dummy
+              :onyx/batch-size 20}]
+   :task-scheduler :onyx.task-scheduler/balanced})
+
+(deftest combined-jobs
+  (let [n-jobs 4
+        n-peers 21
+        job-ids (repeatedly n-jobs #(java.util.UUID/randomUUID))
+        jobs-rets (map (fn [job-id]
+                         (api/create-submit-job-entry job-id
+                                                      peer-config
+                                                      job
+                                                      (planning/discover-tasks (:catalog job) (:workflow job))))
+                       job-ids)]
+    (checking
+     "Checking peers are allocated to job 1 even though job 2 is submitted and can't start."
+     (times 50)
+     [{:keys [replica log peer-choices]}
+      (log-gen/apply-entries-gen
+       (gen/return
+        {:replica base-replica 
+         :message-id 0
+         :entries (assoc (log-gen/generate-join-queues (log-gen/generate-group-and-peer-ids 1 n-peers))
+                         :jobs {:queue jobs-rets})
+         :log []
+         :peer-choices []}))]
+     (is (= 3 (count (:jobs replica))))
+     (println "Jobs" (:jobs replica))
+     (println "Allocatios" (:allocations replica))
+     #_(let [[t1 t2 t3] (:tasks (:args job-1-rets))
+           [t4 t5 t6] (:tasks (:args job-2-rets))]
+       (is (= 3 (count (get (get (:allocations replica) job-1-id) t1))))
+       (is (= 4 (count (get (get (:allocations replica) job-1-id) t2))))
+       (is (= 3 (count (get (get (:allocations replica) job-1-id) t3))))
+
+       (is (= 0 (count (get (get (:allocations replica) job-2-id) t4))))
+       (is (= 0 (count (get (get (:allocations replica) job-2-id) t5))))
+       (is (= 0 (count (get (get (:allocations replica) job-2-id) t6)))))
+     
+     )))


### PR DESCRIPTION
This PR fixes a bug where jobs allocated by the balanced job scheduler potentially act in a greedy way once they are already allocated. This PR ensures that peers are properly spread over coverable jobs.

An additional, unrelated, workaround is included for acking / completing segments on non-input tasks after they are reallocated. This is not the best solution as this mechanism will be replaced soon.