### PR TITLE
Cljs spec compatability

### DIFF
--- a/src/onyx/spec.cljc
+++ b/src/onyx/spec.cljc
@@ -1,6 +1,6 @@
 (ns onyx.spec
   (:require [clojure.spec :as s]
-            [clojure.future :refer [any? boolean? uuid?]]
+            #?(:clj [clojure.future :refer [any? boolean? uuid?]])
             [onyx.information-model :as i]
             [onyx.refinements :as r]
             [onyx.triggers :as t]))
@@ -597,7 +597,7 @@
                 :onyx.peer/state-log-impl
                 :onyx.peer/state-filter-impl
                 :onyx.peer/tags
-                :onyx.peer/trigger-timer-resolution 
+                :onyx.peer/trigger-timer-resolution
                 :onyx.messaging/peer-port
                 :onyx.messaging/external-addr
                 :onyx.messaging/inbound-buffer-size

--- a/src/onyx/spec.cljc
+++ b/src/onyx/spec.cljc
@@ -1,5 +1,6 @@
 (ns onyx.spec
-  (:require [clojure.spec :as s]
+  (:require #?(:clj [clojure.spec :as s]
+               :cljs [cljs.spec :as s :refer-macros [coll-of]])
             #?(:clj [clojure.future :refer [any? boolean? uuid?]])
             [onyx.information-model :as i]
             [onyx.refinements :as r]
@@ -17,6 +18,8 @@
 
 (defn pos-int? [x]
   (and (integer? x) (pos? x)))
+
+(s/def :onyx/name keyword?)
 
 (s/def :job/workflow
   (s/coll-of (s/coll-of :onyx/name :kind vector? :count 2)
@@ -58,8 +61,6 @@
 (s/def :onyx/min-peers pos-int?)
 
 (s/def :onyx/n-peers pos-int?)
-
-(s/def :onyx/name keyword?)
 
 (s/def :onyx/params
   (s/coll-of keyword? :kind vector?))


### PR DESCRIPTION
Addresses https://github.com/onyx-platform/onyx-local-rt/issues/6 

If you change a few ns parameters then the recent cljs compiler won't choke on spec.cljc.