### PR TITLE
Add (:gen-class) directive to allow

### DIFF
--- a/src/onyx/messaging/aeron_media_driver.clj
+++ b/src/onyx/messaging/aeron_media_driver.clj
@@ -1,4 +1,5 @@
 (ns onyx.messaging.aeron-media-driver
+  (:gen-class)
   (:require [clojure.core.async :refer [chan <!!]])
   (:import [io.aeron Aeron$Context]
            [io.aeron.driver MediaDriver MediaDriver$Context ThreadingMode]))


### PR DESCRIPTION
dependent projects to use the media driver
as a jar entrypoint.