### PR TITLE
Trigger locals initialization

### DIFF
--- a/src/onyx/information_model.cljc
+++ b/src/onyx/information_model.cljc
@@ -578,6 +578,10 @@
                                  :type :function
                                  :optional? false
                                  :added "0.9.0"}
+            :trigger/init-locals {:doc "Fn (trigger) to initialise local vars for use in other phases of the trigger."
+                                  :type :function
+                                  :optional? false
+                                  :added "0.9.0"}
             :trigger/next-state {:doc "Fn (trigger, state-event) updates the trigger state in response to a state-event"
                                  :type :function
                                  :optional? false
@@ -2022,7 +2026,7 @@ may be added by the user as the context is associated to throughout the task pip
     :onyx.rocksdb.filter/rotation-check-interval-ms
     :onyx.task-scheduler.colocated/only-send-local?
     :onyx/id]
-   :trigger [:trigger/init-state :trigger/next-state :trigger/trigger-fire?]
+   :trigger [:trigger/init-state :trigger/init-locals :trigger/next-state :trigger/trigger-fire?]
    :state-refinement [:refinement/create-state-update :refinement/apply-state-update] 
    :state-event [:event-type :task-event :segment :grouped?  :group-key :lower-bound 
                  :upper-bound :log-type :trigger-update :aggregation-update :window :next-state]

--- a/src/onyx/schema.cljc
+++ b/src/onyx/schema.cljc
@@ -426,6 +426,7 @@
 
 (s/defschema TriggerCall
   {:trigger/init-state Function
+   :trigger/init-locals Function
    :trigger/next-state Function
    :trigger/trigger-fire? Function})
 

--- a/src/onyx/triggers.cljc
+++ b/src/onyx/triggers.cljc
@@ -33,8 +33,8 @@
   [false (next-fire-time trigger)])
 
 (defn punctuation-init-state
-  [{:keys [trigger/pred] :as trigger}]
-  {:pred-fn (kw->fn pred) :fire? false})
+  [trigger]
+  {:fire? false})
 
 (defn watermark-init-state
   [trigger]
@@ -45,6 +45,23 @@
   [trigger]
   ;; Intentionally return nil - this trigger is stateless.
   )
+
+;; Init local functions
+
+(defn segment-init-locals [trigger]
+  {})
+
+(defn timer-init-locals [trigger]
+  {})
+
+(defn punctuation-init-locals [trigger]
+  {:pred-fn (kw->fn (:trigger/pred trigger))})
+
+(defn watermark-init-locals [trigger]
+  {})
+
+(defn percentile-watermark-init-locals [trigger]
+  {})
 
 ;;; State transition functions
 
@@ -65,8 +82,9 @@
     [fire? (if fire? (next-fire-time trigger) fire-time)]))
 
 (defn punctuation-next-state
-  [trigger {:keys [pred-fn]} state-event]
-  {:pred-fn pred-fn :fire? (pred-fn trigger state-event)})
+  [trigger state {:keys [trigger-state] :as state-event}]
+  (let [{:keys [pred-fn]} trigger-state]
+    {:fire? (pred-fn trigger state-event)}))
 
 (defn watermark-next-state
   [trigger state state-event]
@@ -112,25 +130,30 @@
 ;;; Top level vars to bundle the functions together
 (def ^:export segment
   {:trigger/init-state segment-init-state
+   :trigger/init-locals segment-init-locals
    :trigger/next-state segment-next-state
    :trigger/trigger-fire? segment-fire?})
 
 (def ^:export timer
   {:trigger/init-state timer-init-state
+   :trigger/init-locals timer-init-locals
    :trigger/next-state timer-next-state
    :trigger/trigger-fire? timer-fire?})
 
 (def ^:export punctuation
   {:trigger/init-state punctuation-init-state
+   :trigger/init-locals punctuation-init-locals
    :trigger/next-state punctuation-next-state
    :trigger/trigger-fire? punctuation-fire?})
 
 (def ^:export watermark
   {:trigger/init-state watermark-init-state
+   :trigger/init-locals watermark-init-locals
    :trigger/next-state watermark-next-state
    :trigger/trigger-fire? watermark-fire?})
 
 (def ^:export percentile-watermark
   {:trigger/init-state percentile-watermark-init-state
+   :trigger/init-locals percentile-watermark-init-locals
    :trigger/next-state percentile-watermark-next-state
    :trigger/trigger-fire? percentile-watermark-fire?})

--- a/src/onyx/windowing/window_compile.clj
+++ b/src/onyx/windowing/window_compile.clj
@@ -47,10 +47,13 @@
     (validation/validate-trigger-calls trigger-calls)
     (let [trigger (update trigger :trigger/id #(or % (random-uuid)))
           f-init-state (:trigger/init-state trigger-calls)
+          f-init-locals (:trigger/init-locals trigger-calls)
           sync-fn (if sync (kw->fn sync))
-          emit-fn (if emit (kw->fn emit))]
+          emit-fn (if emit (kw->fn emit))
+          locals (f-init-locals trigger)]
       (-> trigger
           (filter-ns-key-map "trigger")
+          (into locals)
           (assoc :trigger trigger)
           (assoc :sync-fn sync-fn)
           (assoc :emit-fn emit-fn)


### PR DESCRIPTION
Fixes #756. Triggers need a phase to initialize local vars that should not be serialized as checkpoints because their values are either immutable or non-serializable.