### PR TITLE
Control message improvements

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
                  [metrics-clojure "2.9.0"]
                  [com.taoensso/timbre "4.8.0"]
                  [com.taoensso/nippy "2.13.0"]
-                 [io.aeron/aeron-all "1.1.0"]
+                 [io.aeron/aeron-all "1.2.5"]
                  [io.replikativ/hasch "0.3.3" 
                   :exclusions [org.clojure/clojurescript com.cognitect/transit-clj 
                                com.cognitect/transit-cljs org.clojure/data.fressian 

--- a/src/onyx/information_model.cljc
+++ b/src/onyx/information_model.cljc
@@ -1320,6 +1320,13 @@ may be added by the user as the context is associated to throughout the task pip
              :default 100
              :added "0.9.0"}
 
+            :onyx.peer/initial-sync-backoff-ms
+            {:doc "Backoff when waiting for all of the peers to signal readiness to each other."
+             :optional? true
+             :type :integer
+             :default 50
+             :added "0.10.0"}
+
             :onyx.windowing/min-value
             {:doc "A default strict minimum value that `:window/window-key` can ever be. Note, this is generally best configured individually via :window/min-value in the task map."
              :type :integer
@@ -1370,6 +1377,7 @@ may be added by the user as the context is associated to throughout the task pip
              :optional? true
              :type :map
              :added "0.6.0"}
+
 
             :onyx.messaging/inbound-buffer-size
             {:doc "Number of messages to buffer in the core.async channel for received segments."

--- a/src/onyx/messaging/aeron/endpoint_status.clj
+++ b/src/onyx/messaging/aeron/endpoint_status.clj
@@ -1,11 +1,15 @@
 (ns onyx.messaging.aeron.endpoint-status
   (:require [onyx.compression.nippy :refer [messaging-compress messaging-decompress]]
             [onyx.messaging.aeron.utils :as autil :refer [action->kw stream-id heartbeat-stream-id]]
+            [onyx.types :as t]
             [onyx.messaging.common :as common]
             [onyx.messaging.protocols.endpoint-status :as endpoint-status]
             [onyx.messaging.serialize :as sz]
             [onyx.messaging.serializers.segment-decoder :as segment-decoder]
-            [onyx.messaging.serializers.base-decoder :as base-decoder]
+            [onyx.messaging.serializers.base-decoder :as bdec]
+            [onyx.messaging.serializers.heartbeat-decoder :as hbdec]
+            [onyx.messaging.serializers.ready-reply-decoder :as rrdec]
+            [onyx.messaging.serializers.helpers :refer [uncoerce-peer-id coerce-peer-id]]
             [onyx.peer.constants :refer [initialize-epoch]]
             [onyx.static.default-vals :refer [arg-or-default]]
             [onyx.static.util :refer [ms->ns]]
@@ -101,51 +105,50 @@
     this)
   FragmentHandler
   (onFragment [this buffer offset length header]
-    (let [base-dec (base-decoder/->Decoder buffer offset)
-          msg-type (base-decoder/get-type base-dec)
-          msg-rv (base-decoder/get-replica-version base-dec)
-          ;; TODO, avoid full deserialization until we've determined that the message
-          ;; is for us. See below.
-          message (sz/deserialize buffer 
-                                  (+ offset (base-decoder/length base-dec)) 
-                                  (base-decoder/get-payload-length base-dec))
-          msg-sess (:session-id message)]
-      (when (and (= session-id msg-sess) 
-                 (= replica-version msg-rv))
-        (case (int (:type message))
-          2 (when (= peer-id (:dst-peer-id message))
-              (let [src-peer-id (:src-peer-id message)
-                    epoch (:epoch message)
-                    peer-status (or (get statuses src-peer-id) 
-                                    (throw (Exception. "Heartbeating peer does not exist for this replica-version.")))
-                    prev-epoch (:epoch peer-status)]
-                (when-not (or (= epoch (inc prev-epoch))
-                              (= epoch prev-epoch))
-                  (throw (ex-info "Received epoch is not in sync with expected epoch." 
-                                  {:our-replica-version replica-version
-                                   :prev-epoch prev-epoch
-                                   :epoch epoch
-                                   :message message})))
+    (let [base-dec (bdec/->Decoder buffer offset)]
+      (when (= replica-version (bdec/get-replica-version base-dec))
+        (let [msg-type (bdec/get-type base-dec)] 
+          (cond (= msg-type t/heartbeat-id)
+                (let [hb-dec (hbdec/wrap buffer (+ offset (bdec/length base-dec)))] 
+                  (when (and (= session-id (hbdec/get-session-id hb-dec))
+                             (= peer-id (uncoerce-peer-id (hbdec/get-dst-peer-id hb-dec))))
+                    (let [src-peer-id (uncoerce-peer-id (hbdec/get-src-peer-id hb-dec))
+                          peer-status (or (get statuses src-peer-id) 
+                                          (throw (Exception. "Heartbeating peer does not exist for this replica-version.")))
+                          epoch (hbdec/get-epoch hb-dec)
+                          prev-epoch (:epoch peer-status)
+                          opts-map (messaging-decompress (hbdec/get-opts-map-bytes hb-dec))]
+                      (when-not (or (= epoch (inc prev-epoch))
+                                    (= epoch prev-epoch))
+                        (throw (ex-info "Received epoch is not in sync with expected epoch." 
+                                        {:our-replica-version replica-version
+                                         :prev-epoch prev-epoch
+                                         :epoch epoch
+                                         :opts opts-map})))
+                      (->> (update statuses src-peer-id merge {:replica-version replica-version
+                                                               :epoch epoch 
+                                                               :checkpointing? (:checkpointing? opts-map)
+                                                               :drained? (if (contains? opts-map :drained?)
+                                                                           (:drained? opts-map)
+                                                                           false)
+                                                               :min-epoch (:min-epoch opts-map)
+                                                               :heartbeat (System/nanoTime)}) 
+                           (set! statuses))
+                      (set! min-epoch (statuses->min-epoch statuses)))))
 
-                (->> (update statuses src-peer-id merge {:checkpointing? (:checkpointing? message)
-                                                         :replica-version (:replica-version message)
-                                                         :epoch (:epoch message)
-                                                         :drained? (if (contains? message :drained?)
-                                                                     (:drained? message)
-                                                                     false)
-                                                         :min-epoch (:min-epoch message)
-                                                         :heartbeat (System/nanoTime)}) 
-                     (set! statuses))
-                (set! min-epoch (statuses->min-epoch statuses))))
+                (= msg-type t/ready-reply-id)
+                (let [rrdec (rrdec/wrap buffer (+ offset (bdec/length base-dec)))]
+                  (when (and (= session-id (rrdec/get-session-id rrdec))
+                             (= peer-id (uncoerce-peer-id (rrdec/get-dst-peer-id rrdec))))
+                    (let [message (sz/deserialize buffer offset)
+                          src-peer-id (uncoerce-peer-id (rrdec/get-src-peer-id rrdec))] 
+                      (->> (update statuses src-peer-id merge {:ready? true 
+                                                               :heartbeat (System/nanoTime)}) 
+                           (set! statuses))
+                      (set! ready (statuses->ready? statuses)))))
 
-          4 (when (= peer-id (:dst-peer-id message))
-              (let [src-peer-id (:src-peer-id message)] 
-                (->> (update statuses src-peer-id merge {:ready? true 
-                                                         :heartbeat (System/nanoTime)}) 
-                     (set! statuses))
-                (set! ready (statuses->ready? statuses))))
-
-          (throw (ex-info "Invalid message type" {:message message})))))))
+                :else
+                (throw (ex-info "Invalid message type" {:message (sz/deserialize buffer offset)}))))))))
 
 (defn new-endpoint-status [peer-config peer-id session-id]
   (->EndpointStatus peer-config peer-id session-id nil nil (atom nil) nil nil nil nil false)) 

--- a/src/onyx/messaging/aeron/messenger.clj
+++ b/src/onyx/messaging/aeron/messenger.clj
@@ -153,8 +153,9 @@
 
   (offer-barrier [messenger publisher barrier-opts]
     (let [barrier (merge (t/barrier replica-version epoch (pub/short-id publisher)) barrier-opts)
-          buf (sz/serialize barrier)]
-      (let [ret (pub/offer! publisher buf (.capacity buf) (dec epoch))] 
+          buf (UnsafeBuffer. (byte-array 500))
+          len (sz/serialize buf 0 barrier)]
+      (let [ret (pub/offer! publisher buf len (dec epoch))] 
         (debug "Offer barrier:" [:ret ret :message barrier :pub (pub/info publisher)])
         ret))))
 

--- a/src/onyx/messaging/aeron/messenger.clj
+++ b/src/onyx/messaging/aeron/messenger.clj
@@ -55,6 +55,7 @@
                          monitoring
                          id 
                          ticket-counters 
+                         control-message-buf
                          ^:unsynchronized-mutable replica-version 
                          ^:unsynchronized-mutable epoch 
                          ^:unsynchronized-mutable publishers 
@@ -153,13 +154,13 @@
 
   (offer-barrier [messenger publisher barrier-opts]
     (let [barrier (merge (t/barrier replica-version epoch (pub/short-id publisher)) barrier-opts)
-          buf (UnsafeBuffer. (byte-array 500))
-          len (sz/serialize buf 0 barrier)]
-      (let [ret (pub/offer! publisher buf len (dec epoch))] 
+          len (sz/serialize control-message-buf 0 barrier)]
+      (let [ret (pub/offer! publisher control-message-buf len (dec epoch))] 
         (debug "Offer barrier:" [:ret ret :message barrier :pub (pub/info publisher)])
         ret))))
 
 (defmethod m/build-messenger :aeron [peer-config messenger-group monitoring id]
   (->AeronMessenger messenger-group monitoring id 
                     (:ticket-counters messenger-group) 
+                    (UnsafeBuffer. (byte-array onyx.types/max-control-message-size))
                     nil nil nil nil nil))

--- a/src/onyx/messaging/serialize.clj
+++ b/src/onyx/messaging/serialize.clj
@@ -1,50 +1,111 @@
 (ns onyx.messaging.serialize
   (:require [onyx.compression.nippy :refer [messaging-compress messaging-decompress]]
-            [onyx.messaging.serializers.base-encoder :as base-encoder])
+            [onyx.types :as t :refer [barrier ready ready-reply heartbeat]]
+            [onyx.messaging.serializers.helpers :refer [uncoerce-peer-id coerce-peer-id]]
+            [onyx.messaging.serializers.heartbeat-encoder :as hbenc]
+            [onyx.messaging.serializers.heartbeat-decoder :as hbdec]
+            [onyx.messaging.serializers.barrier-encoder :as benc]
+            [onyx.messaging.serializers.barrier-decoder :as bdec]
+            [onyx.messaging.serializers.ready-encoder :as renc]
+            [onyx.messaging.serializers.ready-decoder :as rdec]
+            [onyx.messaging.serializers.ready-reply-encoder :as rrenc]
+            [onyx.messaging.serializers.ready-reply-decoder :as rrdec]
+            [onyx.messaging.serializers.base-decoder :as basedec]
+            [onyx.messaging.serializers.base-encoder :as baseenc])
   (:import [org.agrona.concurrent UnsafeBuffer]
            [onyx.messaging.serializers.base_decoder.Decoder]))
 
 
-(def message-id ^:const (byte 0))
-(def barrier-id ^:const (byte 1))
-(def heartbeat-id ^:const (byte 2))
-(def ready-id ^:const (byte 3))
-(def ready-reply-id ^:const (byte 4))
+(defn deserialize 
+  "Message payload deserializer for when you don't want to interact with decoders directly.
+   Note: slower."
+  [^UnsafeBuffer buf offset]
+  (let [decoder (basedec/wrap (basedec/->Decoder nil offset) buf offset)
+        t (basedec/get-type decoder)
+        rv (basedec/get-replica-version decoder)
+        dest-id (basedec/get-dest-id decoder)
+        base {:type t
+              :replica-version rv
+              :short-id dest-id}]
+    (cond (= t t/heartbeat-id)
+          (let [hb-dec (hbdec/wrap buf (+ offset (basedec/length decoder)))]
+            (merge base 
+                   (messaging-decompress (hbdec/get-opts-map-bytes hb-dec))
+                   {:epoch (hbdec/get-epoch hb-dec)
+                    :session-id (hbdec/get-session-id hb-dec)
+                    :src-peer-id (uncoerce-peer-id (hbdec/get-src-peer-id hb-dec))
+                    :dst-peer-id (uncoerce-peer-id (hbdec/get-dst-peer-id hb-dec))}))
 
-; (defn message [replica-version short-id payload]
-;   {:type message-id :replica-version replica-version :short-id short-id :payload payload})
+          (= t t/ready-reply-id)
+          (let [rrdec (rrdec/wrap buf (+ offset (basedec/length decoder)))] 
+            (merge base 
+                   {:src-peer-id (uncoerce-peer-id (rrdec/get-src-peer-id rrdec))
+                    :dst-peer-id (uncoerce-peer-id (rrdec/get-dst-peer-id rrdec))
+                    :session-id (rrdec/get-session-id rrdec)}))
 
-(defn barrier [replica-version epoch short-id]
-  {:type barrier-id :replica-version replica-version :epoch epoch :short-id short-id})
+          (= t t/ready-id)
+          (let [rdec (rdec/wrap buf (+ offset (basedec/length decoder)))] 
+            (merge base 
+                   {:src-peer-id (uncoerce-peer-id (rdec/get-src-peer-id rdec))}))
 
-;; should be able to get rid of src-peer-id via short-id
-(defn ready [replica-version src-peer-id short-id]
-  {:type ready-id :replica-version replica-version :src-peer-id src-peer-id :short-id short-id})
+          (= t t/barrier-id)
+          (let [bdec (bdec/wrap buf (+ offset (basedec/length decoder)))]
+            (merge base 
+                   {:epoch (bdec/get-epoch bdec)}
+                   (messaging-decompress (bdec/get-opts-map-bytes bdec)))))))
 
-(defn ready-reply [replica-version src-peer-id dst-peer-id session-id short-id]
-  {:type ready-reply-id :replica-version replica-version :src-peer-id src-peer-id 
-   :dst-peer-id dst-peer-id :session-id session-id :short-id short-id})
+(defn serialize 
+  "Message payload serializer for when you don't want to interact with decoders directly.
+   Note: slower than just building it without a map."
+  [^UnsafeBuffer buf offset msg]
+  (let [t (:type msg)
+        enc (-> (baseenc/->Encoder nil offset)
+                (baseenc/wrap buf offset)
+                (baseenc/set-type t)
+                (baseenc/set-replica-version (:replica-version msg))
+                (baseenc/set-dest-id (:short-id msg)))]
+    (cond (= t onyx.types/heartbeat-id)
+          (let [hb-enc (-> (hbenc/wrap buf (baseenc/length enc))
+                           (hbenc/set-epoch (:epoch msg))
+                           (hbenc/set-session-id (:session-id msg))
+                           (hbenc/set-src-peer-id (coerce-peer-id (:src-peer-id msg)))
+                           (hbenc/set-dst-peer-id (coerce-peer-id (:dst-peer-id msg)))
+                           (hbenc/set-opts-map-bytes (-> msg
+                                                         (dissoc :type)
+                                                         (dissoc :replica-version)
+                                                         (dissoc :short-id)
+                                                         (dissoc :session-id)
+                                                         (dissoc :epoch)
+                                                         (dissoc :src-peer-id)
+                                                         (dissoc :dst-peer-id)
+                                                         (messaging-compress))))]
+            (baseenc/set-payload-length enc (hbenc/length hb-enc))
+            (+ (hbenc/length hb-enc) (baseenc/length enc)))
 
-(defn heartbeat [replica-version epoch src-peer-id dst-peer-id session-id short-id]
-  {:type heartbeat-id :replica-version replica-version :epoch epoch 
-   :src-peer-id src-peer-id :dst-peer-id dst-peer-id :session-id session-id
-   :short-id short-id})
+          (= t onyx.types/barrier-id)
+          (let [benc (-> (benc/wrap buf (baseenc/length enc))
+                         (benc/set-epoch (:epoch msg))
+                         (benc/set-opts-map-bytes (-> msg
+                                                      (dissoc :type)
+                                                      (dissoc :replica-version)
+                                                      (dissoc :short-id)
+                                                      (dissoc :epoch)
+                                                      (messaging-compress))))]
+            (baseenc/set-payload-length enc (benc/length benc))
+            (+ (benc/length benc) (baseenc/length enc)))
 
-(defn serialize ^UnsafeBuffer [msg]
-  (let [bs ^bytes (messaging-compress msg)
-        msg-length (alength bs)
-        enc (base-encoder/->Encoder nil 0)
-        buf (UnsafeBuffer. (byte-array (+ msg-length (base-encoder/length enc))))
-        enc (-> enc
-                (base-encoder/wrap buf 0)
-                (base-encoder/set-type (:type msg))
-                (base-encoder/set-replica-version (:replica-version msg))
-                (base-encoder/set-dest-id (:short-id msg))
-                (base-encoder/set-payload-length msg-length))]
-    (.putBytes buf (base-encoder/length enc) bs)
-    buf))  
+          (= t onyx.types/ready-id)
+          (let [renc (-> (renc/wrap buf (baseenc/length enc))
+                         (renc/set-src-peer-id (coerce-peer-id (:src-peer-id msg))))]
+            (baseenc/set-payload-length enc (renc/length renc))
+            (+ (renc/length renc) (baseenc/length enc)))
 
-(defn deserialize [^UnsafeBuffer buf offset length]
-  (let [bs (byte-array length)] 
-    (.getBytes buf offset bs)
-    (messaging-decompress bs)))
+          (= t onyx.types/ready-reply-id)
+          (let [rrenc (-> (rrenc/wrap buf (baseenc/length enc))
+                          (rrenc/set-src-peer-id (coerce-peer-id (:src-peer-id msg)))
+                          (rrenc/set-dst-peer-id (coerce-peer-id (:dst-peer-id msg)))
+                          (rrenc/set-session-id (:session-id msg)))]
+            (baseenc/set-payload-length enc (rrenc/length rrenc))
+            (+ (rrenc/length rrenc) (baseenc/length enc))))))
+
+(comment )

--- a/src/onyx/messaging/serializers/barrier_decoder.clj
+++ b/src/onyx/messaging/serializers/barrier_decoder.clj
@@ -1,0 +1,18 @@
+(ns onyx.messaging.serializers.barrier-decoder
+  (:import [org.agrona.concurrent UnsafeBuffer]))
+
+(defprotocol PDecoder
+  (get-epoch [this])
+  (get-opts-map-bytes [this]))
+
+(deftype Decoder [^UnsafeBuffer buffer offset]
+  PDecoder
+  (get-epoch [this]
+    (.getLong buffer offset))
+  (get-opts-map-bytes [this]
+    (let [bs (byte-array (.getShort buffer (unchecked-add-int offset 8)))] 
+      (.getBytes buffer (unchecked-add-int offset 10) bs)
+      bs)))
+
+(defn wrap [buffer offset]
+  (->Decoder buffer offset))

--- a/src/onyx/messaging/serializers/barrier_encoder.clj
+++ b/src/onyx/messaging/serializers/barrier_encoder.clj
@@ -1,0 +1,32 @@
+(ns onyx.messaging.serializers.barrier-encoder
+  (:require [onyx.messaging.serializers.helpers :refer [type->byte]]) 
+  (:import [org.agrona.concurrent UnsafeBuffer]))
+
+(defprotocol PEncoder
+  (set-epoch [this epoch])
+  (set-opts-map-bytes [this bs])
+  (offset [this])
+  (length [this])
+  (wrap-impl [this buf offset]))
+
+(deftype Encoder [^:unsynchronized-mutable ^UnsafeBuffer buffer ^:unsynchronized-mutable offset]
+  PEncoder
+  (set-epoch [this epoch]
+    (.putLong buffer offset (long epoch))
+    this)
+  (set-opts-map-bytes [this bs]
+    (.putShort buffer (unchecked-add-int offset 8) (short (alength ^bytes bs)))
+    (.putBytes buffer (unchecked-add-int offset 10) ^bytes bs)
+    this)
+  (offset [this] offset)
+  (length [this] 
+    (unchecked-add-int 10 (.getShort buffer (unchecked-add-int offset 8))))
+  (wrap-impl [this buf new-offset] 
+    (set! offset new-offset)
+    (set! buffer buf)
+    (.putShort buffer (unchecked-add-int new-offset 8) (short 0))
+    this))
+
+(defn wrap [buffer offset]
+  (-> (->Encoder nil nil)
+      (wrap-impl buffer offset)))

--- a/src/onyx/messaging/serializers/heartbeat_decoder.clj
+++ b/src/onyx/messaging/serializers/heartbeat_decoder.clj
@@ -1,0 +1,32 @@
+(ns onyx.messaging.serializers.heartbeat-decoder
+  (:require [onyx.messaging.serializers.helpers :refer [byte->type]])
+  (:import [org.agrona.concurrent UnsafeBuffer]))
+
+(defprotocol PDecoder
+  (get-epoch [this])
+  (get-src-peer-id [this])
+  (get-dst-peer-id [this])
+  (get-session-id [this])
+  (get-opts-map-bytes [this]))
+
+(deftype Decoder [^UnsafeBuffer buffer offset]
+  PDecoder
+  (get-epoch [this]
+    (.getLong buffer offset))
+  (get-src-peer-id [this]
+    [(byte->type (.getByte buffer (unchecked-add-int offset 8)))
+     (java.util.UUID. (.getLong buffer (unchecked-add-int offset 9))
+                      (.getLong buffer (unchecked-add-int offset 17)))])
+  (get-dst-peer-id [this]
+    [(byte->type (.getByte buffer (unchecked-add-int offset 25)))
+     (java.util.UUID. (.getLong buffer (unchecked-add-int offset 26))
+                      (.getLong buffer (unchecked-add-int offset 34)))])
+  (get-session-id [this]
+    (.getLong buffer (unchecked-add-int offset 42)))
+  (get-opts-map-bytes [this]
+    (let [bs (byte-array (.getShort buffer (unchecked-add-int offset 50)))] 
+      (.getBytes buffer (unchecked-add-int offset 52) bs)
+      bs)))
+
+(defn wrap [buffer offset]
+  (->Decoder buffer offset))

--- a/src/onyx/messaging/serializers/heartbeat_encoder.clj
+++ b/src/onyx/messaging/serializers/heartbeat_encoder.clj
@@ -1,0 +1,48 @@
+(ns onyx.messaging.serializers.heartbeat-encoder
+  (:require [onyx.messaging.serializers.helpers :refer [type->byte]])         
+  (:import [org.agrona.concurrent UnsafeBuffer]))
+
+(defprotocol PEncoder
+  (set-epoch [this epoch])
+  (set-dst-peer-id [this peer-id])
+  (set-src-peer-id [this peer-id])
+  (set-session-id [this session-id])
+  (set-opts-map-bytes [this bs])
+  (offset [this])
+  (length [this])
+  (wrap-impl [this buf offset]))
+
+(deftype Encoder [^:unsynchronized-mutable ^UnsafeBuffer buffer ^:unsynchronized-mutable offset]
+  PEncoder
+  (set-epoch [this epoch]
+    (.putLong buffer offset (long epoch))
+    this)
+  (set-src-peer-id [this [peer-type peer-id]]
+    (.putByte buffer (unchecked-add-int offset 8) (type->byte peer-type))
+    (.putLong buffer (unchecked-add-int offset 9) (.getMostSignificantBits ^java.util.UUID peer-id))
+    (.putLong buffer (unchecked-add-int offset 17) (.getLeastSignificantBits ^java.util.UUID peer-id))
+    this)
+  (set-dst-peer-id [this [peer-type peer-id]]
+    (.putByte buffer (unchecked-add-int offset 25) (type->byte peer-type))
+    (.putLong buffer (unchecked-add-int offset 26) (.getMostSignificantBits ^java.util.UUID peer-id))
+    (.putLong buffer (unchecked-add-int offset 34) (.getLeastSignificantBits ^java.util.UUID peer-id))
+    this)
+  (set-session-id [this session-id]
+    (.putLong buffer (unchecked-add-int offset 42) (long session-id))
+    this)
+  (set-opts-map-bytes [this bs]
+    (.putShort buffer (unchecked-add-int offset 50) (short (alength ^bytes bs)))
+    (.putBytes buffer (unchecked-add-int offset 52) ^bytes bs)
+    this)
+  (offset [this] offset)
+  (length [this] 
+    (unchecked-add-int 52 (.getShort buffer (unchecked-add-int offset 50))))
+  (wrap-impl [this buf new-offset] 
+    (set! offset new-offset)
+    (set! buffer buf)
+    (.putShort buffer (unchecked-add-int new-offset 50) (short 0))
+    this))
+
+(defn wrap [buffer offset]
+  (-> (->Encoder nil nil)
+      (wrap-impl buffer offset)))

--- a/src/onyx/messaging/serializers/helpers.clj
+++ b/src/onyx/messaging/serializers/helpers.clj
@@ -1,0 +1,29 @@
+(ns onyx.messaging.serializers.helpers)
+
+;; These functions are a hacky workaround for the fact that coordinator peer-ids take the form:
+;; [:coordinator #uuid ...]
+;; and peer peer-ids takes the form:
+;; #uuid ...
+;; A future refactor will ensure they both take the vector form
+
+(def coordinator (byte 0))
+(def peer (byte 1))
+
+(def byte->type
+  {coordinator :coordinator
+   peer :task})
+
+(def type->byte
+  {:coordinator coordinator
+   :task peer})
+
+(defn coerce-peer-id [peer-id]
+  (if (vector? peer-id) peer-id
+    [:task peer-id]))
+
+(defn uncoerce-peer-id [peer-id]
+  (if (= :task (first peer-id))
+    (second peer-id)
+    peer-id))
+
+

--- a/src/onyx/messaging/serializers/ready_decoder.clj
+++ b/src/onyx/messaging/serializers/ready_decoder.clj
@@ -1,0 +1,16 @@
+(ns onyx.messaging.serializers.ready-decoder
+  (:require [onyx.messaging.serializers.helpers :refer [byte->type]])
+  (:import [org.agrona.concurrent UnsafeBuffer]))
+
+(defprotocol PDecoder
+  (get-src-peer-id [this]))
+
+(deftype Decoder [^UnsafeBuffer buffer offset]
+  PDecoder
+  (get-src-peer-id [this]
+    [(byte->type (.getByte buffer offset))
+     (java.util.UUID. (.getLong buffer (unchecked-add-int offset 1))
+                      (.getLong buffer (unchecked-add-int offset 9)))]))
+
+(defn wrap [buffer offset]
+  (->Decoder buffer offset))

--- a/src/onyx/messaging/serializers/ready_encoder.clj
+++ b/src/onyx/messaging/serializers/ready_encoder.clj
@@ -1,0 +1,28 @@
+(ns onyx.messaging.serializers.ready-encoder
+  (:require [onyx.messaging.serializers.helpers :refer [type->byte]])
+  (:import [org.agrona.concurrent UnsafeBuffer]))
+
+(defprotocol PEncoder
+  (set-src-peer-id [this peer-id])
+  (offset [this])
+  (length [this])
+  (wrap-impl [this buf offset]))
+
+(deftype Encoder [^:unsynchronized-mutable ^UnsafeBuffer buffer ^:unsynchronized-mutable offset]
+  PEncoder
+  (set-src-peer-id [this [peer-type peer-id]]
+    (.putByte buffer offset (type->byte peer-type))
+    (.putLong buffer (unchecked-add-int offset 1) (.getMostSignificantBits ^java.util.UUID peer-id))
+    (.putLong buffer (unchecked-add-int offset 9) (.getLeastSignificantBits ^java.util.UUID peer-id))
+    this)
+  (offset [this] offset)
+  (length [this]
+    17)
+  (wrap-impl [this buf new-offset] 
+    (set! offset new-offset)
+    (set! buffer buf)
+    this))
+
+(defn wrap [buffer offset]
+  (-> (->Encoder nil nil)
+      (wrap-impl buffer offset)))

--- a/src/onyx/messaging/serializers/ready_reply_decoder.clj
+++ b/src/onyx/messaging/serializers/ready_reply_decoder.clj
@@ -1,0 +1,25 @@
+(ns onyx.messaging.serializers.ready-reply-decoder
+  (:require [onyx.messaging.serializers.helpers :refer [byte->type]])
+  (:import [org.agrona.concurrent UnsafeBuffer]))
+
+(defprotocol PDecoder
+  (get-epoch [this])
+  (get-src-peer-id [this])
+  (get-dst-peer-id [this])
+  (get-session-id [this]))
+
+(deftype Decoder [^UnsafeBuffer buffer offset]
+  PDecoder
+  (get-src-peer-id [this]
+    [(byte->type (.getByte buffer offset))
+     (java.util.UUID. (.getLong buffer (unchecked-add-int offset 1))
+                      (.getLong buffer (unchecked-add-int offset 9)))])
+  (get-dst-peer-id [this]
+    [(byte->type (.getByte buffer (unchecked-add-int offset 17)))
+     (java.util.UUID. (.getLong buffer (unchecked-add-int offset 18))
+                      (.getLong buffer (unchecked-add-int offset 26)))])
+  (get-session-id [this]
+    (.getLong buffer (unchecked-add-int offset 34))))
+
+(defn wrap [buffer offset]
+  (->Decoder buffer offset))

--- a/src/onyx/messaging/serializers/ready_reply_encoder.clj
+++ b/src/onyx/messaging/serializers/ready_reply_encoder.clj
@@ -1,0 +1,38 @@
+(ns onyx.messaging.serializers.ready-reply-encoder
+  (:require [onyx.messaging.serializers.helpers :refer [type->byte]]) 
+  (:import [org.agrona.concurrent UnsafeBuffer]))
+
+(defprotocol PEncoder
+  (set-dst-peer-id [this peer-id])
+  (set-src-peer-id [this peer-id])
+  (set-session-id [this session-id])
+  (offset [this])
+  (length [this])
+  (wrap-impl [this buf offset]))
+
+
+(deftype Encoder [^:unsynchronized-mutable ^UnsafeBuffer buffer ^:unsynchronized-mutable offset]
+  PEncoder
+  (set-src-peer-id [this [peer-type peer-id]]
+    (.putByte buffer offset (type->byte peer-type))
+    (.putLong buffer (unchecked-add-int offset 1) (.getMostSignificantBits ^java.util.UUID peer-id))
+    (.putLong buffer (unchecked-add-int offset 9) (.getLeastSignificantBits ^java.util.UUID peer-id))
+    this)
+  (set-dst-peer-id [this [peer-type peer-id]]
+    (.putByte buffer (unchecked-add-int offset 17) (type->byte peer-type))
+    (.putLong buffer (unchecked-add-int offset 18) (.getMostSignificantBits ^java.util.UUID peer-id))
+    (.putLong buffer (unchecked-add-int offset 26) (.getLeastSignificantBits ^java.util.UUID peer-id))
+    this)
+  (set-session-id [this session-id]
+    (.putLong buffer (unchecked-add-int offset 34) (long session-id))
+    this)
+  (offset [this] offset)
+  (length [this] 42)
+  (wrap-impl [this buf new-offset] 
+    (set! offset new-offset)
+    (set! buffer buf)
+    this))
+
+(defn wrap [buffer offset]
+  (-> (->Encoder nil nil)
+      (wrap-impl buffer offset)))

--- a/src/onyx/messaging/serializers/segment_decoder.clj
+++ b/src/onyx/messaging/serializers/segment_decoder.clj
@@ -4,14 +4,14 @@
 (defprotocol PDecoder
   (next-value [this])
   (length [this])
-  (wrap [this ^UnsafeBuffer buffer offset]))
+  (wrap-impl [this ^UnsafeBuffer buffer offset]))
 
 (deftype Decoder [^bytes bs
                   ^:unsynchronized-mutable ^UnsafeBuffer buffer
                   ^:unsynchronized-mutable n
                   ^:unsynchronized-mutable offset]
   PDecoder
-  (wrap [this new-buffer new-offset]
+  (wrap-impl [this new-buffer new-offset]
     (set! buffer new-buffer)
     (set! n (- (.getShort ^UnsafeBuffer new-buffer new-offset) (Short/MIN_VALUE)))
     (set! offset (unchecked-add-int new-offset 2))
@@ -25,6 +25,10 @@
         (set! n (unchecked-add-int n -1))
         (set! offset (unchecked-add-int new-offset msg-length))
         bs))))
+
+(defn wrap [read-buffer staging-bytes offset]
+  (-> (->Decoder staging-bytes nil nil nil)
+      (wrap-impl read-buffer offset))) 
 
 (defn read-segments! [decoder vs deserializer-fn]
   (loop []

--- a/src/onyx/peer/task_lifecycle.clj
+++ b/src/onyx/peer/task_lifecycle.clj
@@ -40,8 +40,8 @@
                      goto-recover! heartbeat! killed? next-epoch!
                      next-replica! new-iteration? log-state reset-event!
                      sealed? set-context! set-windows-state! set-sealed!
-                     set-replica! set-coordinator!  set-messenger! set-epoch!
-                     update-event!]]
+                     set-replica! set-coordinator! set-messenger! set-epoch! 
+                     initial-sync-backoff update-event!]]
             [onyx.plugin.messaging-output :as mo]
             [onyx.plugin.protocols :as p]
             [onyx.windowing.window-compile :as wc]
@@ -276,13 +276,6 @@
             (advance))
         state)
       (goto-next-batch! state))))
-
-(def initial-sync-backoff-ns ^:const (* 50 1000000))
-
-(defn initial-sync-backoff [state]
-  (when (zero? (t/epoch state))
-    (LockSupport/parkNanos initial-sync-backoff-ns))
-  state)
 
 (defn offer-barriers [state]
   (let [messenger (get-messenger state)
@@ -634,8 +627,9 @@
     (into upstream downstream)))
 
 (deftype TaskStateMachine [monitoring
-                           subscriber-liveness-timeout-ms
-                           publisher-liveness-timeout-ms
+                           subscriber-liveness-timeout-ns
+                           publisher-liveness-timeout-ns
+                           initial-sync-backoff-ns
                            input-pipeline
                            output-pipeline
                            ^IdleStrategy idle-strategy
@@ -697,9 +691,15 @@
                   (.update heartbeat-timer (- (System/nanoTime) hb) TimeUnit/NANOSECONDS))
                 (all-heartbeat-times messenger))
           ;; check if downstream peers are still up
-          (->> (timed-out-subscribers pubs subscriber-liveness-timeout-ms)
+          (->> (timed-out-subscribers pubs subscriber-liveness-timeout-ns)
                (reduce evict-peer! this)))
         this)))
+
+  (initial-sync-backoff [this]
+    (when (zero? (t/epoch this))
+      (LockSupport/parkNanos initial-sync-backoff-ns))
+    this)
+
   (log-state [this]
     (let [task-map (:onyx.core/task-map event)]
       (info "Task state"
@@ -896,6 +896,7 @@
     (->TaskStateMachine monitoring
                         (ms->ns (arg-or-default :onyx.peer/subscriber-liveness-timeout-ms peer-config))
                         (ms->ns (arg-or-default :onyx.peer/publisher-liveness-timeout-ms peer-config))
+                        (ms->ns (arg-or-default :onyx.peer/initial-sync-backoff-ms peer-config))
                         input-plugin output-plugin idle-strategy recover-idx iteration-idx batch-idx
                         (count state-fns) names state-fns start-idx false false base-replica messenger 
                         messenger-group coordinator event event window-states nil replica-version 

--- a/src/onyx/protocol/task_state.clj
+++ b/src/onyx/protocol/task_state.clj
@@ -17,6 +17,7 @@
   (get-windows-state [this])
   (set-windows-state! [this new-windows-state])
   (get-lifecycle [this])
+  (initial-sync-backoff [this])
   (log-state [this])
   (heartbeat! [this])
   (reset-event! [this])

--- a/src/onyx/schema.cljc
+++ b/src/onyx/schema.cljc
@@ -697,6 +697,7 @@
    (s/optional-key :onyx.zookeeper/backoff-max-sleep-time-ms) s/Int
    (s/optional-key :onyx.zookeeper/backoff-max-retries) s/Int
    (s/optional-key :onyx.zookeeper/prepare-failure-detection-interval) s/Int
+   (s/optional-key :onyx.messaging/initial-sync-backoff-ms) s/Int
    (s/optional-key :onyx.messaging/inbound-buffer-size) (deprecated [:peer-config :model :onyx.messaging/inbound-buffer-size])
    (s/optional-key :onyx.messaging/completion-buffer-size) (deprecated [:peer-config :model :onyx.messaging/completion-buffer-size])
    (s/optional-key :onyx.messaging/release-ch-buffer-size)(deprecated [:peer-config :model :onyx.messaging/release-ch-buffer-size])

--- a/src/onyx/types.cljc
+++ b/src/onyx/types.cljc
@@ -2,11 +2,13 @@
 
 (defrecord Route [flow exclusions post-transformation action])
 
-(def message-id (byte 0))
-(def barrier-id (byte 1))
-(def heartbeat-id (byte 2))
-(def ready-id (byte 3))
-(def ready-reply-id (byte 4))
+(def message-id ^:const (byte 0))
+(def barrier-id ^:const (byte 1))
+(def heartbeat-id ^:const (byte 2))
+(def ready-id ^:const (byte 3))
+(def ready-reply-id ^:const (byte 4))
+
+(def max-control-message-size 500)
 
 (defn message [replica-version short-id payload]
   {:type message-id :replica-version replica-version :short-id short-id :payload payload})
@@ -14,7 +16,6 @@
 (defn barrier [replica-version epoch short-id]
   {:type barrier-id :replica-version replica-version :epoch epoch :short-id short-id})
 
-;; should be able to get rid of src-peer-id via short-id
 (defn ready [replica-version src-peer-id short-id]
   {:type ready-id :replica-version replica-version :src-peer-id src-peer-id :short-id short-id})
 


### PR DESCRIPTION
Backs off initial ready and heartbeat messages on synchronising the network. Implements serializers for all message types rather than relying on nippy, which allows us to do deserialize parts of the messages and ignore messages that are not intended for us, cutting down serialization overhead.

Also cleans up some messy code, though parts still could use a further refactor.