### PR TITLE
Measure peer group lag

### DIFF
--- a/src/onyx/monitoring/metrics_monitoring.clj
+++ b/src/onyx/monitoring/metrics_monitoring.clj
@@ -85,6 +85,13 @@
                                            (fn [] 
                                              (ns->ms (- (System/nanoTime)
                                                         (.get ^AtomicLong last-heartbeat)))))
+          scheduler-lag (AtomicLong. (System/nanoTime))
+          peer-group-scheduler-lag (g/gauge-fn reg
+                                               ["peer-group" "scheduler-lag"] 
+                                               (fn [] 
+                                                 (ns->ms (- (System/nanoTime)
+                                                            (.get ^AtomicLong scheduler-lag)))))
+
           reporter (-> (JmxReporter/forRegistry reg)
                        (.inDomain "org.onyxplatform")
                        (.build))
@@ -94,6 +101,7 @@
              :monitoring :custom
              :registry reg
              :reporter reporter
+             :set-scheduler-lag! (fn [^long v] (.set ^AtomicLong scheduler-lag v))
              :peer-group-heartbeat! (fn [] (.set ^AtomicLong last-heartbeat ^long (System/nanoTime)))
              :peer-error! (fn [] (m/mark! peer-error-rate))
              :zookeeper-write-log-entry (fn [config metric] 

--- a/src/onyx/peer/task_lifecycle.clj
+++ b/src/onyx/peer/task_lifecycle.clj
@@ -168,12 +168,12 @@
         start (System/nanoTime)
         checkpoint-bytes (checkpoint-compress checkpoint)]
     (update-timer-ns! (:checkpoint-serialization-latency monitoring) (- (System/nanoTime) start))
+    (.set ^AtomicLong (:checkpoint-size monitoring) (alength checkpoint-bytes))
     (when (and (not (nil? checkpoint)) 
                (not (fixed-npeers? (get-event state))))
       (throw (ex-info "Task is not checkpointable, as the task onyx/n-peers is not set and :onyx/min-peers is not equal to :onyx/max-peers."
                       {:job-id job-id
                        :task task-id})))
-    (.set ^AtomicLong (:checkpoint-size monitoring) (alength checkpoint-bytes))
     (checkpoint/write-checkpoint storage tenancy-id job-id rv e task-id 
                                  slot-id :input checkpoint-bytes)
     (debug "Checkpointed input" job-id rv e task-id slot-id :input)
@@ -190,11 +190,11 @@
         start (System/nanoTime)
         checkpoint-bytes (checkpoint-compress exported-state)]
     (update-timer-ns! (:checkpoint-serialization-latency monitoring) (- (System/nanoTime) start))
+    (.set ^AtomicLong (:checkpoint-size monitoring) (alength checkpoint-bytes))
     (when-not (fixed-npeers? (get-event state))
       (throw (ex-info "Task is not checkpointable, as the task onyx/n-peers is not set and :onyx/min-peers is not equal to :onyx/max-peers."
                       {:job-id job-id
                        :task task-id})))
-    (.set ^AtomicLong (:checkpoint-size monitoring) (alength checkpoint-bytes))
     (checkpoint/write-checkpoint storage tenancy-id job-id rv e task-id 
                                  slot-id :windows checkpoint-bytes)
     (debug "Checkpointed state" job-id rv e task-id slot-id :windows)
@@ -210,12 +210,12 @@
         start (System/nanoTime)
         checkpoint-bytes (checkpoint-compress checkpoint)]
     (update-timer-ns! (:checkpoint-serialization-latency monitoring) (- (System/nanoTime) start))
+    (.set ^AtomicLong (:checkpoint-size monitoring) (alength checkpoint-bytes))
     (when (and (not (nil? checkpoint)) 
                (not (fixed-npeers? (get-event state))))
       (throw (ex-info "Task is not checkpointable, as the task onyx/n-peers is not set and :onyx/min-peers is not equal to :onyx/max-peers."
                       {:job-id job-id
                        :task task-id})))
-    (.set ^AtomicLong (:checkpoint-size monitoring) (alength checkpoint-bytes))
     (checkpoint/write-checkpoint storage tenancy-id job-id rv e 
                                  task-id slot-id :output checkpoint-bytes)
     (debug "Checkpointed output" job-id rv e task-id slot-id :output)

--- a/src/onyx/peer/task_lifecycle.clj
+++ b/src/onyx/peer/task_lifecycle.clj
@@ -583,7 +583,7 @@
   (let [task-types (cond-> #{(:onyx/type task-map)}
                      (windowed-task? event) (conj :windowed))
         phase-order [:recover :start-iteration :barriers :process-batch :heartbeat]]
-    (->> (reduce #(into %1 (get lifecycles %2)) [] phase-order)
+    (->> (reduce (fn [accum phase] (into accum (get lifecycles phase))) [] phase-order)
          (filter (fn [lifecycle]
                    ;; see information_model.cljc for :type of task that should use
                    ;; each lifecycle type.

--- a/src/onyx/peer/task_lifecycle.clj
+++ b/src/onyx/peer/task_lifecycle.clj
@@ -421,7 +421,7 @@
 (def task-iterations 1)
 
 (defn run-task-lifecycle!
-  "The main task run loop, read batch, ack messages, etc."
+  "The main task run loop, read batch, write batch, checkpoint, etc."
   [state handle-exception-fn exception-action-fn]
   (try
     (let [{:keys [onyx.core/replica-atom] :as event} (get-event state)]

--- a/test-resources/test-config.edn
+++ b/test-resources/test-config.edn
@@ -6,7 +6,7 @@
  :peer-config
  {:zookeeper/address "127.0.0.1:2188"
   :onyx.peer/job-scheduler :onyx.job-scheduler/greedy
-  :onyx.peer/storage :s3
+  :onyx.peer/storage :zookeeper
   :onyx.peer/storage.s3.bucket "onyx-s3-testing"
   :onyx.peer/storage.s3.region "us-west-2"
   ;:onyx.peer/storage.s3.bucket "onyx-test-us-east-1"


### PR DESCRIPTION
Measure peer group lag behind cluster log, measures serialization latency as planned.