### PR TITLE
Improve peer liveness detection.

### DIFF
--- a/src/onyx/messaging/aeron/endpoint_status.clj
+++ b/src/onyx/messaging/aeron/endpoint_status.clj
@@ -45,7 +45,7 @@
     (:drained? opts-map)
     false))
 
-(defn peer-status [replica-version epoch opts-map]
+(defn new-peer-status [replica-version epoch opts-map]
   {:replica-version replica-version
    :epoch epoch 
    :checkpointing? (:checkpointing? opts-map)
@@ -142,7 +142,7 @@
                                          :prev-epoch prev-epoch
                                          :epoch epoch
                                          :opts opts-map})))
-                      (->> (peer-status replica-version epoch opts-map)
+                      (->> (new-peer-status replica-version epoch opts-map)
                            (update statuses src-peer-id merge)
                            (set! statuses))
                       (set! min-epoch (statuses->min-epoch statuses)))))

--- a/src/onyx/monitoring/metrics_monitoring.clj
+++ b/src/onyx/monitoring/metrics_monitoring.clj
@@ -90,7 +90,11 @@
                                                ["peer-group" "scheduler-lag"] 
                                                (fn [] 
                                                  (.get ^AtomicLong scheduler-lag)))
-
+          number-peer-shutdowns (AtomicLong. 0)
+          peer-group-num-peer-shutdowns (g/gauge-fn reg
+                                                   ["peer-group" "peers-shutting-down"] 
+                                                   (fn [] 
+                                                     (.get ^AtomicLong number-peer-shutdowns)))
           reporter (-> (JmxReporter/forRegistry reg)
                        (.inDomain "org.onyxplatform")
                        (.build))
@@ -101,6 +105,7 @@
              :registry reg
              :reporter reporter
              :set-scheduler-lag! (fn [^long v] (.set ^AtomicLong scheduler-lag v))
+             :set-num-peer-shutdowns! (fn [^long v] (.set ^AtomicLong number-peer-shutdowns v))
              :peer-group-heartbeat! (fn [] (.set ^AtomicLong last-heartbeat ^long (System/nanoTime)))
              :peer-error! (fn [] (m/mark! peer-error-rate))
              :zookeeper-write-log-entry (fn [config metric] 

--- a/src/onyx/peer/liveness.clj
+++ b/src/onyx/peer/liveness.clj
@@ -1,0 +1,26 @@
+(ns onyx.peer.liveness
+  (:require [onyx.protocol.task-state :as t :refer [evict-peer! get-messenger]]
+            [onyx.messaging.protocols.status-publisher :as status-pub]
+            [onyx.messaging.protocols.subscriber :as sub]
+            [onyx.messaging.protocols.publisher :as pub]))
+
+(defn upstream-timed-out-peers [subscriber liveness-timeout-ns]
+  (let [curr-time (System/nanoTime)]
+    (->> subscriber
+         (sub/status-pubs)
+         (sequence (comp (filter (fn [[peer-id spub]] 
+                                   (< (+ (status-pub/get-heartbeat spub)
+                                         liveness-timeout-ns)
+                                      curr-time)))
+                         (map key))))))
+
+(defn downstream-timed-out-peers [publishers timeout-ms]
+  (let [curr-time (System/nanoTime)] 
+    (sequence (comp (mapcat pub/statuses)
+                    (filter (fn [[peer-id status]] 
+                              (< (+ (:heartbeat status) timeout-ms)
+                                 curr-time)))
+                    (map key))
+              publishers)))
+
+

--- a/src/onyx/peer/virtual_peer.clj
+++ b/src/onyx/peer/virtual_peer.clj
@@ -47,10 +47,7 @@
 
   (stop [{:keys [outbox-ch group-id id state] :as component}]
     (taoensso.timbre/info (format "Stopping Virtual Peer %s" (:id component)))
-
-    (when-let [f (:lifecycle-stop-fn state)]
-      (common/stop-lifecycle-safe! f :peer-left state))
-
+    (common/stop-lifecycle-peer-group! state :peer-left)
     (>!! outbox-ch
          {:fn :leave-cluster
           :peer-parent id

--- a/test/onyx/peer/min_peers_test.clj
+++ b/test/onyx/peer/min_peers_test.clj
@@ -40,8 +40,7 @@
                            :onyx/tenancy-id id
                            :onyx.peer/coordinator-barrier-period-ms 50)]
     (with-expect-call [(:do coordinator/periodic-barrier [_])
-                       (:do :more coordinator/periodic-barrier [_])
-                       (:do coordinator/shutdown [_])]
+                       (:do :more coordinator/periodic-barrier [_])]
       (with-test-env [test-env [3 env-config peer-config]]
         (let [batch-size 20
               catalog [{:onyx/name :in


### PR DESCRIPTION
Adds additional liveness detection check after polling in the recovery phase.
Adds additional liveness detection check in the coordinator.
Monitor task shutdown futures in peer group, warn when they take a long time to shutdown, track shutting down peer count as a metric.