### PR TITLE
Alter handling of trigger/emit'd segments

### DIFF
--- a/src/onyx/information_model.cljc
+++ b/src/onyx/information_model.cljc
@@ -809,6 +809,8 @@ may be added by the user as the context is associated to throughout the task pip
                                            :doc "A map containing `:tree`: the mapping of segments to the newly created segments, `:segments`: the newly created segments, `:retries`: the segments that will be retried from the input source."}
                        :onyx.core/triggered {:type [:segment]
                                              :optional? true
+                                             :deprecated-version "0.11.2"
+                                             :deprecated-doc ":onyx.core/triggered has been deprecated in favour of placing the :trigger/emit results in onyx.core/results."
                                              :doc "A sequential containing segments emitted by `:trigger/emit`."}
                        :onyx.core/scheduler-event {:type :keyword
                                                    :choices peer-scheduler-event-types

--- a/src/onyx/plugin/messaging_output.clj
+++ b/src/onyx/plugin/messaging_output.clj
@@ -62,16 +62,13 @@
          (nil? full-pub)
          (empty? queued-offers)))
   p/Output
-  (prepare-batch [this {:keys [onyx.core/results onyx.core/triggered] :as event} replica messenger]
+  (prepare-batch [this {:keys [onyx.core/results] :as event} replica messenger]
     (.set size 0)
     (run! (fn [result]
             (run! (fn [seg]
                     (add-segment segments routes size seg event result))
                   (:leaves result)))
           (:tree results))
-    (run! (fn [seg] 
-            (add-segment segments routes size seg event {:leaves [seg]}))
-          triggered)
     (run! pub/reset-segment-encoder! (m/publishers messenger))
     (set! queued-offers nil)
     (set! full-pub nil)


### PR DESCRIPTION
by placing them in onyx.core/results rather than onyx.core/triggered.
This allows them to be automatically processed by output plugins.