### PR TITLE
Allow job-config to be supplied to job.

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,8 @@
+## 0.12.1
+* Fixed an bug in the new `:checkpointed` windowed state event type, where incorrect barrier number may be supplied after a peer crash.
+* Added a new `:job-config` key to the job map.
+* `:job-config` option allows `:onyx.peer/coordinator-barrier-period-ms` to be supplied per job.
+
 ## 0.12.0
 
 0.11 and 0.12 bring a number of small breaking changes that were necessary to fix some flaws in Onyx's usability. After 0.12 the pace of these breaking changes will be reduced.

--- a/src/onyx/api.clj
+++ b/src/onyx/api.clj
@@ -208,6 +208,7 @@
   (extensions/write-chunk (:log client) :triggers (:triggers job) job-id)
   (extensions/write-chunk (:log client) :job-metadata (:metadata job) job-id)
   (extensions/write-chunk (:log client) :job-name (or (:job-name job) job-id) job-id)
+  (extensions/write-chunk (:log client) :job-config (or (:job-config job) {}) job-id)
   (doseq [task-resume-point (:resume-point job)]
     (extensions/write-chunk (:log client) :resume-point task-resume-point job-id))
   (doseq [task tasks]

--- a/src/onyx/information_model.cljc
+++ b/src/onyx/information_model.cljc
@@ -134,26 +134,10 @@
            :tags [:task]
            :optional? true
            :added "0.9.0"}
-:acker/percentage {:type :double
-                   :tags []
-                   :optional? true
-                   :deprecated-version "0.10.0"
-                   :deprecation-doc ":acker/percentage was deprecated in  0.10.0 when ackers were removed."}
-:acker/exempt-input-tasks? {:type :any
-                            :tags []
-                            :optional? true
-                            :deprecated-version "0.10.0"
-                            :deprecation-doc ":acker/exempt-input-tasks? was deprecated in 0.10.0 when ackers were removed."}
-:acker/exempt-output-tasks? {:type :any
-                             :tags []
-                             :optional? true
-                             :deprecated-version "0.10.0"
-                             :deprecation-doc ":acker/exempt-output-tasks? was deprecated in 0.10.0 when ackers were removed."}
-:acker/exempt-tasks {:type :any
-                     :tags []
-                     :optional? true
-                     :deprecated-version "0.10.0"
-                     :deprecation-doc ":acker/exempt-tasks was deprecated in 0.10.0 when ackers were removed."}}}
+
+:job-config {:doc "Parameters specific to the job being submitted. In some cases these options may override peer-config entries."}}}
+
+
          :catalog-entry
          {:summary "All inputs, outputs, and functions in a workflow must be described via a catalog. A catalog is a vector of maps, strikingly similar to Datomic’s schema. Configuration and docstrings are described in the catalog."
           :doc-url "http://www.onyxplatform.org/docs/user-guide/latest/#_catalog"
@@ -817,6 +801,8 @@ may be added by the user as the context is associated to throughout the task pip
                                             :doc "The core.async channel to deliver restart notifications to the peer"}
                        :onyx.core/peer-opts {:type :peer-config
                                              :doc "The options that this peer was started with"}
+                       :onyx.core/job-config {:type :job-config
+                                              :doc "The job specific configuration."}
                        :onyx.core/replica-atom {:type :replica-atom
                                                 :doc "The replica that this peer has currently accrued."}
                        :onyx.core/resume-point {:type :any
@@ -1135,6 +1121,16 @@ may be added by the user as the context is associated to throughout the task pip
                                          :type :function
                                          :optional? true
                                          :added "0.8.3"}}}
+
+   :job-config
+  {:summary "All options available to configure the job. Parameters may override peer-config options."
+    :link nil
+    :model {:onyx.peer/coordinator-barrier-period-ms
+            {:doc "A coordinator will send another barrier if it has been `:onyx.peer/coordinator-barrier-period-ms` ms since it last sent a barrier. Will override the peer-config option of the same name."
+             :type :integer
+             :unit :millisecond
+             :optional? true
+             :added "0.12.1"}}}
 
    :peer-config
    {:summary "All options available to configure the virtual peers and development environment."
@@ -1722,12 +1718,8 @@ may be added by the user as the context is associated to throughout the task pip
 
 (def model-display-order
   {:job [:job-name :workflow :catalog :flow-conditions :windows
-         :triggers :metadata :lifecycles
-         :resume-point :task-scheduler :percentage
-         :acker/exempt-tasks 
-         :acker/exempt-input-tasks? 
-         :acker/percentage
-         :acker/exempt-output-tasks?]
+         :triggers :metadata :lifecycles :job-config
+         :resume-point :task-scheduler :percentage]
    :catalog-entry
    [:onyx/name
     :onyx/type
@@ -1788,6 +1780,7 @@ may be added by the user as the context is associated to throughout the task pip
     :lifecycle/after-ack-segment 
     :lifecycle/after-retry-segment
     :lifecycle/handle-exception]
+   :job-config [:onyx.peer/coordinator-barrier-period-ms]
    :peer-config
    [:onyx/tenancy-id
     :zookeeper/address
@@ -1864,6 +1857,7 @@ may be added by the user as the context is associated to throughout the task pip
                :onyx.core/lifecycles 
                :onyx.core/resume-point
                :onyx.core/fn
+               :onyx.core/job-config
                :onyx.core/params
                :onyx.core/metadata 
                :onyx.core/batch
@@ -1887,6 +1881,7 @@ may be added by the user as the context is associated to throughout the task pip
                :onyx.core/kill-flag 
                :onyx.core/task-kill-flag
                :onyx.core/log-prefix
+               :onyx.core/job-config
                :onyx.core/serialized-task
                :onyx.core/log
                :onyx.core/storage

--- a/src/onyx/log/zookeeper.clj
+++ b/src/onyx/log/zookeeper.clj
@@ -45,6 +45,9 @@
 (defn job-name-path [prefix]
   (str (prefix-path prefix) "/job-name"))
 
+(defn job-config-path [prefix]
+  (str (prefix-path prefix) "/job-config"))
+
 (defn workflow-path [prefix]
   (str (prefix-path prefix) "/workflow"))
 
@@ -68,9 +71,6 @@
 
 (defn task-path [prefix]
   (str (prefix-path prefix) "/task"))
-
-(defn sentinel-path [prefix]
-  (str (prefix-path prefix) "/sentinel"))
 
 (defn chunk-path [prefix]
   (str (prefix-path prefix) "/chunk"))
@@ -128,6 +128,7 @@
       (zk/create conn (log-path onyx-id) :persistent? true)
       (zk/create conn (job-hash-path onyx-id) :persistent? true)
       (zk/create conn (job-name-path onyx-id) :persistent? true)
+      (zk/create conn (job-config-path onyx-id) :persistent? true)
       (zk/create conn (catalog-path onyx-id) :persistent? true)
       (zk/create conn (workflow-path onyx-id) :persistent? true)
       (zk/create conn (flow-path onyx-id) :persistent? true)
@@ -136,7 +137,6 @@
       (zk/create conn (triggers-path onyx-id) :persistent? true)
       (zk/create conn (job-metadata-path onyx-id) :persistent? true)
       (zk/create conn (task-path onyx-id) :persistent? true)
-      (zk/create conn (sentinel-path onyx-id) :persistent? true)
       (zk/create conn (chunk-path onyx-id) :persistent? true)
       (zk/create conn (origin-path onyx-id) :persistent? true)
       (zk/create conn (log-parameters-path onyx-id) :persistent? true)
@@ -427,6 +427,18 @@
                   :latency % :bytes (count bytes)}]
         (extensions/emit monitoring args)))))
 
+(defmethod extensions/write-chunk [ZooKeeper :job-config]
+  [{:keys [conn opts prefix monitoring] :as log} kw chunk id]
+  (let [bytes (zookeeper-compress chunk)]
+    (measure-latency
+     #(clean-up-broken-connections
+       (fn []
+         (let [node (str (job-config-path prefix) "/" id)]
+           (zk/create conn node :persistent? true :data bytes))))
+     #(let [args {:event :zookeeper-job-config :id id
+                  :latency % :bytes (count bytes)}]
+        (extensions/emit monitoring args)))))
+
 (defmethod extensions/write-chunk [ZooKeeper :triggers]
   [{:keys [conn opts prefix monitoring] :as log} kw chunk id]
   (let [bytes (zookeeper-compress chunk)]
@@ -536,6 +548,16 @@
        (let [node (str (job-hash-path prefix) "/" id)]
          (zookeeper-decompress (:data (zk/data conn node))))))
    #(let [args {:event :zookeeper-read-job-hash :id id :latency %}]
+      (extensions/emit monitoring args))))
+
+(defmethod extensions/read-chunk [ZooKeeper :job-config]
+  [{:keys [conn opts prefix monitoring] :as log} kw id & _]
+  (measure-latency
+   #(clean-up-broken-connections
+     (fn []
+       (let [node (str (job-config-path prefix) "/" id)]
+         (zookeeper-decompress (:data (zk/data conn node))))))
+   #(let [args {:event :zookeeper-read-job-config :id id :latency %}]
       (extensions/emit monitoring args))))
 
 (defmethod extensions/read-chunk [ZooKeeper :catalog]

--- a/src/onyx/peer/coordinator.clj
+++ b/src/onyx/peer/coordinator.clj
@@ -257,12 +257,17 @@
             (LockSupport/parkNanos coordinator-max-sleep-ns)
             state))))
 
+(defn barrier-period [job-config peer-config]
+  (ms->ns 
+   (or (:onyx.peer/coordinator-barrier-period-ms job-config)
+       (arg-or-default :onyx.peer/coordinator-barrier-period-ms peer-config))))
+
 (defn start-coordinator!
-  [{:keys [allocation-ch shutdown-ch peer-config] :as state}]
+  [{:keys [allocation-ch shutdown-ch peer-config job-config] :as state}]
   (thread
     (try
      (let [coordinator-max-sleep-ns (ms->ns (arg-or-default :onyx.peer/coordinator-max-sleep-ms peer-config))
-           barrier-period-ns (ms->ns (arg-or-default :onyx.peer/coordinator-barrier-period-ms peer-config))
+           barrier-period-ns (barrier-period job-config peer-config)
            heartbeat-ns (ms->ns (arg-or-default :onyx.peer/heartbeat-ms peer-config))
            result (loop [state (initialise-state state)]
                     (if-let [scheduler-event (poll! shutdown-ch)]
@@ -305,7 +310,7 @@
     (close! allocation-ch)))
 
 (defrecord PeerCoordinator
-           [workflow resume-point log messenger-group peer-config peer-id job-id monitoring
+           [workflow resume-point log messenger-group peer-config job-config peer-id job-id monitoring
             messenger group-ch allocation-ch shutdown-ch coordinator-thread]
   Coordinator
   (start [this]
@@ -329,6 +334,7 @@
                                    :resume-point resume-point
                                    :log log
                                    :evicted #{}
+                                   :job-config job-config
                                    :peer-config peer-config
                                    :messenger messenger
                                    :curr-replica initial-replica
@@ -356,13 +362,14 @@
         (emit-replica new-replica)))))
 
 (defn new-peer-coordinator
-  [workflow resume-point log messenger-group monitoring peer-config peer-id job-id group-ch]
+  [workflow resume-point log messenger-group monitoring peer-config job-config peer-id job-id group-ch]
   (map->PeerCoordinator {:workflow workflow
                          :monitoring monitoring
                          :resume-point resume-point
                          :log log
                          :group-ch group-ch
                          :messenger-group messenger-group
+                         :job-config job-config
                          :peer-config peer-config
                          :peer-id peer-id
                          :job-id job-id}))

--- a/src/onyx/schema.cljc
+++ b/src/onyx/schema.cljc
@@ -646,25 +646,21 @@
            (s/optional-key :windows) {WindowId WindowResumeDefinition}}})
 
 (s/defschema JobConfig
-   {(s/optional-key :onyx.peer/coordinator-barrier-period-ms) PosInt})
+  {(s/optional-key :onyx.peer/coordinator-barrier-period-ms) PosInt})
 
 (s/defschema Job
   {:catalog Catalog
    :workflow Workflow
    :task-scheduler TaskScheduler
    (s/optional-key :job-name) JobName
+   (s/optional-key :job-config) JobConfig
    (s/optional-key :resume-point) ResumePoint
    (s/optional-key :percentage) s/Int
    (s/optional-key :flow-conditions) [FlowCondition]
    (s/optional-key :windows) [Window]
    (s/optional-key :triggers) [Trigger]
    (s/optional-key :lifecycles) [Lifecycle]
-   (s/optional-key :metadata) JobMetadata
-   (s/optional-key :config) JobConfig
-   (s/optional-key :acker/percentage) s/Int
-   (s/optional-key :acker/exempt-input-tasks?) (deprecated [:job :model :acker/exempt-input-tasks?])
-   (s/optional-key :acker/exempt-output-tasks?) (deprecated [:job :model :acker/exempt-output-tasks?])
-   (s/optional-key :acker/exempt-tasks) (deprecated [:job :model :acker/exempt-tasks])})
+   (s/optional-key :metadata) JobMetadata})
 
 (s/defschema PartialJob
   (assoc Job :workflow PartialWorkflow))
@@ -914,6 +910,7 @@
        :AtomicInteger s/Any
        :segment s/Any
        :peer-config PeerConfig
+       :job-config JobConfig
        :catalog-entry TaskMap
        :window-entry Window
        :trigger-entry Trigger

--- a/test/onyx/doc_test.clj
+++ b/test/onyx/doc_test.clj
@@ -72,12 +72,11 @@
 
 (deftest check-model-display-order
   (testing "Checks whether all keys in information model are accounted for in ordering used in cheat sheet"
-    (is (= (map (fn [k]
-                  (set (keys (:model (model k)))))
-                (keys model))
-           (map (fn [k]
-                  (set (model-display-order k)))
-                (keys model))))))
+    (run!
+     (fn [k] (is 
+              (= (set (keys (:model (model k))))
+                 (set (model-display-order k)))))
+     (keys model))))
 
 
 (comment (defn build-deprecations-strings [version]

--- a/test/onyx/generative/peer_model.clj
+++ b/test/onyx/generative/peer_model.clj
@@ -353,7 +353,7 @@
 
 (defn next-state [prev-state {:keys [command type] :as event} replica]
   (cond (= command :task-iteration) 
-        (tl/iteration prev-state replica 1)
+        (exec prev-state)
 
         (= type :coordinator)
         (->> (next-coordinator-action (get-coordinator prev-state) command replica)

--- a/test/onyx/peer/min_peers_test.clj
+++ b/test/onyx/peer/min_peers_test.clj
@@ -37,8 +37,7 @@
         config (load-config)
         env-config (assoc (:env-config config) :onyx/tenancy-id id)
         peer-config (assoc (:peer-config config) 
-                           :onyx/tenancy-id id
-                           :onyx.peer/coordinator-barrier-period-ms 50)]
+                           :onyx/tenancy-id id)]
     (with-expect-call [(:do coordinator/periodic-barrier [_])
                        (:do :more coordinator/periodic-barrier [_])]
       (with-test-env [test-env [3 env-config peer-config]]
@@ -79,6 +78,7 @@
                                                      :workflow workflow
                                                      :lifecycles lifecycles
                                                      :task-scheduler :onyx.task-scheduler/balanced
+                                                     :job-config {:onyx.peer/coordinator-barrier-period-ms 50}
                                                      :metadata {:job-name :click-stream}})
               _ (onyx.test-helper/feedback-exception! peer-config job-id)
               results (take-segments! @out-chan 1)]


### PR DESCRIPTION
job-config allows certain configuration parameters to be supplied per
job, rather than via the peer-config for the entire cluster.