### PR TITLE
async checkpoint recovery.

### DIFF
--- a/test/onyx/windowing/basic_windowing_crash_test.clj
+++ b/test/onyx/windowing/basic_windowing_crash_test.clj
@@ -173,11 +173,9 @@
         (let [{:keys [job-id]} (onyx.api/submit-job peer-config job)
               _ (onyx.test-helper/feedback-exception! peer-config job-id)
               results (take-segments! @out-chan 5)]
-          (println "COORDS" (onyx.api/job-snapshot-coordinates peer-config id job-id))
+          (println "Snapshot coordinates:" (onyx.api/job-snapshot-coordinates peer-config id job-id))
+          (println "GC checkpoints.")
           (onyx.api/gc-checkpoints peer-config id job-id)
-          (println "Try again" )
+          (println "GC checkpoints a second time.")
           (onyx.api/gc-checkpoints peer-config id job-id)
-          ;; FIXME: improve test by pulling in old coordinates, recovering and then starting gc again.
-          ;; TODO, allow gc to take part over tenancy history.
-
           (is (= expected-windows (output->final-counts @test-state))))))))


### PR DESCRIPTION
Ensures heartbeating continues during the recovery process.

TODO: add timeout to recover process so that peers can't get stuck forever.