### PR TITLE
Support custom checkpoint storage implementations

### DIFF
--- a/src/onyx/information_model.cljc
+++ b/src/onyx/information_model.cljc
@@ -1230,10 +1230,9 @@ may be added by the user as the context is associated to throughout the task pip
             :onyx.peer/storage
             {:doc "Storage type to use for checkpointing."
              :type :keyword
-             :choices [:s3 :zookeeper :any]
+             :choices [:s3 :zookeeper]
              :default :zookeeper
              :optional? true
-             :restrictions ["Must match the keyword provided by the desired storage implementation."]
              :added "0.10.0"}
 
             :onyx.peer/storage.timeout

--- a/src/onyx/information_model.cljc
+++ b/src/onyx/information_model.cljc
@@ -1230,9 +1230,10 @@ may be added by the user as the context is associated to throughout the task pip
             :onyx.peer/storage
             {:doc "Storage type to use for checkpointing."
              :type :keyword
-             :choices [:s3 :zookeeper]
+             :choices [:s3 :zookeeper :any]
              :default :zookeeper
              :optional? true
+             :restrictions ["Must match the keyword provided by the desired storage implementation."]
              :added "0.10.0"}
 
             :onyx.peer/storage.timeout

--- a/src/onyx/schema.cljc
+++ b/src/onyx/schema.cljc
@@ -702,7 +702,7 @@
   {:zookeeper/address s/Str
    s/Keyword s/Any})
 
-(s/defschema Storage (s/enum :s3 :zookeeper))
+(s/defschema Storage s/Keyword)
 
 (s/defschema LifecycleState
   (s/enum :lifecycle/poll-recover :lifecycle/offer-barriers


### PR DESCRIPTION
This has been tested with a custom storage implementation and with built-in :zookeeper. I have no easy way of testing it with :s3.

Went ahead and updated the info model so the change would be reflected in the documentation (using some assumptions based on context).  Feel free to change/wordsmith/delete!