### PR TITLE
Fix tiny typos

### DIFF
--- a/doc/user-guide/architecture-low-level-design.adoc
+++ b/doc/user-guide/architecture-low-level-design.adoc
@@ -64,7 +64,7 @@ its input channels.
 
 Concepts:
 
-- Barrier: a message injected into the data stream, containing the epoch id of the barrier
+- Barrier: a message injected into the data stream, containing the epoch id of the barrier.
 - Epoch: the id of the barrier, re-starting from 0 whenever the cluster has performed a reallocation.
 - Coordinator - a process that injects a barrier into the data stream on a schedule.
 - Barrier Alignment: occurs when barriers with a particular id have been received from all input channels on a peer.
@@ -124,7 +124,7 @@ in order on the inbox, and messages to-be-sent are placed in order on
 the outbox.
 
 Messages arrive in the inbox as commands are proposed into the ZooKeeper
-log. Technically, the inbox need only be size 1 since all log entries
+log. Technically, the inbox needs only be size 1 since all log entries
 are processed strictly in order. As an optimization, the peer can choose
 to read a few extra commands behind the one it's currently processing.
 In practice, the inbox will probably be configured with a size greater
@@ -212,7 +212,7 @@ of this znode is a UUID.
 
 ==== 3-Phase Cluster Join Strategy
 
-When a peer wishes to join the cluster, it must engage in a 3 phase
+When a peer wishes to join the cluster, it must engage in a 3-phase
 protocol. Three phases are required because the peer that is joining
 needs to coordinate with another peer to change its ZooKeeper watch. I
 call this process "stitching" a peer into the cluster.
@@ -320,10 +320,10 @@ while joining]
 
 === Dead peer removal
 
-Peers will fail, or be shut down purposefully. Onyx needs to: - detect
-the downed peer - inform all peers that this peer is no longer executing
-its task - inform all peers that this peer is no longer part of the
-cluster
+Peers will fail, or be shut down purposefully. Onyx needs to:
+- detect the downed peer
+- inform all peers that this peer is no longer executing its task
+- inform all peers that this peer is no longer part of the cluster
 
 ==== Peer Failure Detection Strategy
 

--- a/doc/user-guide/flow-conditions.adoc
+++ b/doc/user-guide/flow-conditions.adoc
@@ -91,7 +91,7 @@ A predicate function is a Clojure function that takes at least four
 parameters - a context map, the old segment, the new segment, and the
 collection of all new segments produced from the old segment. Predicates
 can take parameters at runtime. They will be appended to the end of the
-function invocation. See Predicate Parameters for further discussion of
+function invocation. See <<Predicate Parameters>> for further discussion of
 how to use runtime parameters.
 
 Predicates for the above examples can be seen below:

--- a/doc/user-guide/what-does-it-offer.adoc
+++ b/doc/user-guide/what-does-it-offer.adoc
@@ -31,8 +31,8 @@ Macros are a tremendously powerful tool, but are often inappropriate for
 end-user consumption of an API. Onyx goes beyond Storm's `defbolt` and
 `defspout` by making vanilla Clojure functions shine. These functions
 need no context to execute and do not require any dynamic bindings. They
-receive _all_ information that they need via parameters, which are
-injected by Onyx's task lifecycles.
+receive _all_ information they need via parameters, which are injected
+by Onyx's task lifecycles.
 
 === Plain Clojure Functions
 
@@ -54,7 +54,7 @@ mocking code required.
 
 === Easy Parameterization of Workflows
 
-It's particularly telling that many compute frameworks don't offer an
+It's particularly telling that many computing frameworks don't offer an
 easy way to parameterize workflows. Onyx puts space between the caller
 and the function definition. Parameterize tasks inside the catalog, and
 update the catalog entry at will. Additionally, Onyx allows peers to
@@ -65,13 +65,6 @@ spin up their own parameters at boot-up time.
 Onyx uses the notion of a _sentinel value_ to transparently switch
 between streaming and batching modes. This makes it really easy to be
 able to reuse the same code for both batch and streaming computations.
-
-=== Aspect Orientation
-
-Clojure functions again serve as a huge win.
-https://github.com/MichaelDrogalis/dire[Dire] is a library that supports
-aspects, meaning you can keep your application logic airtight away from
-logging, preconditions, and error handling.
 
 === AOT Nothing
 


### PR DESCRIPTION
Read until section Messaging.

In section 'What does it offer?', the paragraph 'Aspect Orientation' is removed according to https://github.com/onyx-platform/onyx/issues/852#issuecomment-373346063.