### PR TITLE
Link user guide to terminal reduce task example

### DIFF
--- a/doc/user-guide/windowing.adoc
+++ b/doc/user-guide/windowing.adoc
@@ -31,6 +31,9 @@ as emitted to downstream tasks in lieu of the transformed segments.
 
 When `:onyx/type :reduce` is used on a terminal task, `:onyx/plugin` is no longer mandatory.
 
+TIP: Example project:
+https://github.com/onyx-platform/onyx-examples/tree/0.13.x/terminal-reduce-task[terminal-reduce-task]
+
 === Window Types
 
 The topic of windows has been widely explored in the literature. There


### PR DESCRIPTION
Currently, the link does not work because the example is not available in the `0.13.x` branch. If this were to be merged, the [example][example] would have to be merged from `master` into that branch. I opened this assuming that would be a good idea.

[example]: https://github.com/onyx-platform/onyx-examples/tree/master/terminal-reduce-task