### PR TITLE
Allow job snapshot coordinates to be looked up by job-name AND tenancy-id

### DIFF
--- a/src/onyx/api.clj
+++ b/src/onyx/api.clj
@@ -304,6 +304,10 @@
      (finally
       (zk/close conn)))))
 
+(defmethod job-ids-history OnyxClient
+  [client job-name]
+  (job-ids-history (:conn (:log client)) job-name))
+
 (defmulti clear-job-data
   "Takes a peer-config, zookeeper-address string, or a curator connection, and deletes
    all job chunks from ZooKeeper. This should be performed when the job is no longer running and its immutable
@@ -327,6 +331,10 @@
      (finally
       (zk/close conn)))))
 
+(defmethod clear-job-data OnyxClient
+  [client tenancy-id job-id]
+  (clear-job-data (:conn (:log client)) tenancy-id job-id))
+
 (defmulti clear-tenancy
   "Takes a zookeeper-address string or a curator connection, and deletes
    all data for a given tenancy from ZooKeeper, including job data and cluster logs. 
@@ -347,6 +355,10 @@
      (clear-tenancy conn tenancy-id)
      (finally
       (zk/close conn)))))
+
+(defmethod clear-tenancy OnyxClient
+  [client tenancy-id]
+  (clear-tenancy (:conn (:log client)) tenancy-id))
 
 (defmulti job-snapshot-coordinates
   "Reads the latest full snapshot coordinate stored for a given job-id and


### PR DESCRIPTION
This adds a way for the client to restrict snapshot look-ups by job name to a particular tenancy id.

I was getting checkpoint not found bugs when I had two parallel tenancies running in my zk cluster - then I realized the (job-snapshot-coordinates client job-name) method was using global state and returning jobs with mixed tenancy ids.

