### PR TITLE
Implement claim-spare-peers for greedy scheduler

### DIFF
--- a/src/onyx/scheduling/balanced_job_scheduler.clj
+++ b/src/onyx/scheduling/balanced_job_scheduler.clj
@@ -63,8 +63,7 @@
   (loop [jobs* jobs n* n]
     (if (zero? n*)
       jobs*
-      (let [job (select-job-requiring-peer replica jobs* n*)]
-        (if job
-          (recur (update jobs* job inc)
-                 (dec n*))
-          jobs*)))))
+      (if-let [job (select-job-requiring-peer replica jobs* n*)]
+        (recur (update jobs* job inc)
+               (dec n*))
+        jobs*))))

--- a/src/onyx/scheduling/greedy_job_scheduler.clj
+++ b/src/onyx/scheduling/greedy_job_scheduler.clj
@@ -2,12 +2,10 @@
   (:require [clojure.set :refer [subset?]]
             [onyx.scheduling.common-job-scheduler :as cjs]
             [onyx.scheduling.common-task-scheduler :as cts]
-            [onyx.log.commands.common :as common]))
+            [onyx.log.commands.common :as common]
+            [taoensso.timbre :refer [debug info warn spy]]))
 
-(defn job-coverable? [replica job]
-  (let [min-req (apply + (vals (get-in replica [:min-required-peers job])))]
-    (>= (count (get-in replica [:peers])) min-req)))
-
+; {JobId -> Int}
 (defmethod cjs/job-offer-n-peers :onyx.job-scheduler/greedy
   [replica jobs]
   (if (seq jobs)
@@ -16,11 +14,25 @@
              (zipmap passive (repeat 0))))
     {}))
 
+; {JobId -> Int}
 (defmethod cjs/claim-spare-peers :onyx.job-scheduler/greedy
   [replica jobs n]
-  ;; This is a trivial case. A Greedy job scheduler has already offered
-  ;; all the peers to the first available job. If there are extra peers,
-  ;; they would simply be offered back to the same job, which would refuse
-  ;; them. Return the same job claims since nothing will change.
-  ;;
-  jobs)
+  ;; Take all the claimable peers
+  ;; 1. Allocate as many to the first coverable job that it may maximally use
+  ;; 2. Continue with the rest of the jobs until all jobs or peers are exhausted.
+  (loop [claims jobs
+         jobs* jobs
+         n* n]
+    (if (zero? n*)
+      claims
+      (if-let [[job-id peer-count] (first jobs*)]
+        (let [n-requested (- (cjs/job-upper-bound replica job-id) peer-count)
+              n-required (- (cjs/job-lower-bound replica job-id) peer-count)
+              n-alloc (if (<= n-required n*) (min n* n-requested) 0)]
+          (if (pos? n-alloc)
+            (recur
+              (update claims job-id + n-alloc)
+              (rest jobs*)
+              (- n* n-alloc))
+            (recur claims (rest jobs*) n*)))
+        claims))))


### PR DESCRIPTION
Fixes issue #569

The greedy scheduler was not allocating peers beyond the first job when the job had it's max-peers satisfied. This implements a greedy algorithm to allocate as many peers as they may use to jobs in the order they were created.