### PR TITLE
Add optional key `:onyx/percentage` into base-task-map schema.

### DIFF
--- a/src/onyx/schema.cljc
+++ b/src/onyx/schema.cljc
@@ -94,6 +94,7 @@
    (s/optional-key :onyx/max-peers) PosInt
    (s/optional-key :onyx/min-peers) PosInt
    (s/optional-key :onyx/n-peers) PosInt
+   (s/optional-key :onyx/percentage) PosInt
    (s/optional-key :onyx/required-tags) [s/Keyword]
    (restricted-ns :onyx) s/Any})
 


### PR DESCRIPTION
Add `:onyx/percentage` as an optional key into base-task-map schema, so that we can set percentage  for each individual catalog entry in job definition when using percentage task scheduler, as suggested [here](http://www.onyxplatform.org/docs/user-guide/0.14.x/#_percentage_task_scheduler).