### PR TITLE
Add optional key `:onyx/percentage` into base-task-map schema.

### DIFF
--- a/src/onyx/information_model.cljc
+++ b/src/onyx/information_model.cljc
@@ -219,6 +219,14 @@
                    :optional? true
                    :added "0.8.0"}
 
+                  :onyx/percentage
+                  {:doc "For use with percentage task scheduler. Defines the percentage of the peers for this job that the task should receive."
+                   :type :integer
+                   :tags [:task :scheduler]
+                   :restrictions ["Value must be integers between 1 and 99, inclusive."]
+                   :optional? true
+                   :added "0.14.5"}
+
                   :onyx/language
                   {:doc "Designates the language that the function denoted by `:onyx/fn` is implemented in."
                    :type :keyword
@@ -1734,6 +1742,7 @@ may be added by the user as the context is associated to throughout the task pip
     :onyx/min-peers
     :onyx/max-peers
     :onyx/n-peers
+    :onyx/percentage
     :onyx/language
     :onyx/params
     :onyx/medium

--- a/src/onyx/schema.cljc
+++ b/src/onyx/schema.cljc
@@ -94,6 +94,7 @@
    (s/optional-key :onyx/max-peers) PosInt
    (s/optional-key :onyx/min-peers) PosInt
    (s/optional-key :onyx/n-peers) PosInt
+   (s/optional-key :onyx/percentage) PosInt
    (s/optional-key :onyx/required-tags) [s/Keyword]
    (restricted-ns :onyx) s/Any})
 


### PR DESCRIPTION
This is a follow-up PR to fix the failing test in this [PR](https://github.com/onyx-platform/onyx/pull/892).

After adding the information model for `:onyx/percentage`, this [test](https://github.com/onyx-platform/onyx/blob/0.14.x/test/onyx/doc_test.clj#L37-L43) shouldn't fail anymore, and the documents for `:onyx/percentage` should show up in [cheat sheet](http://www.onyxplatform.org/docs/cheat-sheet/latest/#/catalog-entry).

Running `lein test` in my local shows
```shell
$ lein test
...
Ran 160 tests containing 525 assertions.
0 failures, 0 errors.
```