### PR TITLE
Log as :info level when Aeron starts up in a healthy state

### DIFF
--- a/src/onyx/peer/peer_group_manager.clj
+++ b/src/onyx/peer/peer_group_manager.clj
@@ -274,7 +274,7 @@
 
           (and (not (:up? state)) (media-driver-healthy? media-driver-dir))
           (do
-           (warn "Aeron media driver is healthy, thus starting all peers.")
+           (info "Aeron media driver is healthy, thus starting all peers.")
            (action state-shutdown [:start-peer-group]))
 
           :else


### PR DESCRIPTION
The program should not be producing warnings if it starts up normally (which can create false alarms in downstream monitoring)